### PR TITLE
Add VitePress docs site with TypeDoc API reference

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,49 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: Generate API reference
+        run: bun run docs:api
+
+      - name: Build docs
+        run: bun run vitepress build docs
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -106,5 +106,12 @@ dist
 # macOS
 .DS_Store
 
+# VitePress
+docs/.vitepress/dist
+docs/.vitepress/cache
+
+# Generated API docs (rebuilt on deploy)
+docs/api
+
 # Claude
 .claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md — builtwith-api
+
+## Project overview
+
+TypeScript wrapper for the BuiltWith API suite. Exposes all 13 API endpoints as a **library**, **CLI**, and **MCP server**. Published on npm as `builtwith-api`.
+
+## Tech stack
+
+- **Runtime**: Bun (build, test, compile)
+- **Language**: TypeScript (strict mode, ESM-only)
+- **Validation**: Zod v4 (`zod/v4` import path)
+- **Linting**: Biome
+- **Docs**: VitePress + TypeDoc
+
+## Key conventions
+
+- **Schemas are the source of truth** — all types are inferred from Zod schemas via `z.infer<>`. Never duplicate types manually.
+- **Response schemas use `z.strictObject()`** — this catches upstream API drift. If BuiltWith adds new fields, the schema parse will fail, signaling that the schema needs updating.
+- **Input schemas also use `z.strictObject()`** — prevents typos in option names from being silently ignored.
+- **Dual request functions** — `request()` for strict JSON parsing, `requestSafe()` for endpoints (lists, trends) that occasionally return malformed JSON.
+- **Commands registry** — `src/commands.ts` defines all 13 commands once; both CLI and MCP consume the same definitions.
+- **Minimal dependencies** — only `zod` and `@modelcontextprotocol/sdk` at runtime.
+
+## Commands
+
+```bash
+bun run build       # Build JS + type declarations
+bun run lint        # Biome check
+bun run lint:fix    # Biome auto-fix
+bun test            # Run all tests
+bun run docs:dev    # Local docs dev server
+```
+
+## File structure
+
+```
+src/
+  index.ts      — createClient() factory, all 13 API methods
+  schemas.ts    — Zod schemas for inputs + responses, BuiltWithClient interface
+  commands.ts   — Command registry shared by CLI and MCP
+  params.ts     — URL building, query string, boolean flag mapping
+  request.ts    — HTTP request + Zod validation
+  errors.ts     — Error formatting (Zod + generic)
+  config.ts     — Constants (response format enum)
+  cli.ts        — CLI entry point
+  mcp.ts        — MCP server entry point
+test/
+  *.test.ts     — Unit + integration tests (Bun test runner)
+```
+
+## CI/CD
+
+- `.github/workflows/ci.yml` — lint + build + test on push/PR to main
+- `.github/workflows/docs.yml` — build and deploy VitePress docs to GitHub Pages
+- `.github/workflows/release.yml` — auto-create GitHub release + compile cross-platform binaries when version changes

--- a/bun.lock
+++ b/bun.lock
@@ -11,11 +11,58 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.7",
         "@types/bun": "^1.3.9",
+        "typedoc": "^0.28.17",
+        "typedoc-plugin-markdown": "^4.10.0",
         "typescript": "^5",
+        "vitepress": "^1.6.4",
       },
     },
   },
   "packages": {
+    "@algolia/abtesting": ["@algolia/abtesting@1.15.2", "", { "dependencies": { "@algolia/client-common": "5.49.2", "@algolia/requester-browser-xhr": "5.49.2", "@algolia/requester-fetch": "5.49.2", "@algolia/requester-node-http": "5.49.2" } }, "sha512-rF7vRVE61E0QORw8e2NNdnttcl3jmFMWS9B4hhdga12COe+lMa26bQLfcBn/Nbp9/AF/8gXdaRCPsVns3CnjsA=="],
+
+    "@algolia/autocomplete-core": ["@algolia/autocomplete-core@1.17.7", "", { "dependencies": { "@algolia/autocomplete-plugin-algolia-insights": "1.17.7", "@algolia/autocomplete-shared": "1.17.7" } }, "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q=="],
+
+    "@algolia/autocomplete-plugin-algolia-insights": ["@algolia/autocomplete-plugin-algolia-insights@1.17.7", "", { "dependencies": { "@algolia/autocomplete-shared": "1.17.7" }, "peerDependencies": { "search-insights": ">= 1 < 3" } }, "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A=="],
+
+    "@algolia/autocomplete-preset-algolia": ["@algolia/autocomplete-preset-algolia@1.17.7", "", { "dependencies": { "@algolia/autocomplete-shared": "1.17.7" }, "peerDependencies": { "@algolia/client-search": ">= 4.9.1 < 6", "algoliasearch": ">= 4.9.1 < 6" } }, "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA=="],
+
+    "@algolia/autocomplete-shared": ["@algolia/autocomplete-shared@1.17.7", "", { "peerDependencies": { "@algolia/client-search": ">= 4.9.1 < 6", "algoliasearch": ">= 4.9.1 < 6" } }, "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg=="],
+
+    "@algolia/client-abtesting": ["@algolia/client-abtesting@5.49.2", "", { "dependencies": { "@algolia/client-common": "5.49.2", "@algolia/requester-browser-xhr": "5.49.2", "@algolia/requester-fetch": "5.49.2", "@algolia/requester-node-http": "5.49.2" } }, "sha512-XyvKCm0RRmovMI/ChaAVjTwpZhXdbgt3iZofK914HeEHLqD1MUFFVLz7M0+Ou7F56UkHXwRbpHwb9xBDNopprQ=="],
+
+    "@algolia/client-analytics": ["@algolia/client-analytics@5.49.2", "", { "dependencies": { "@algolia/client-common": "5.49.2", "@algolia/requester-browser-xhr": "5.49.2", "@algolia/requester-fetch": "5.49.2", "@algolia/requester-node-http": "5.49.2" } }, "sha512-jq/3qvtmj3NijZlhq7A1B0Cl41GfaBpjJxcwukGsYds6aMSCWrEAJ9pUqw/C9B3hAmILYKl7Ljz3N9SFvekD3Q=="],
+
+    "@algolia/client-common": ["@algolia/client-common@5.49.2", "", {}, "sha512-bn0biLequn3epobCfjUqCxlIlurLr4RHu7RaE4trgN+RDcUq6HCVC3/yqq1hwbNYpVtulnTOJzcaxYlSr1fnuw=="],
+
+    "@algolia/client-insights": ["@algolia/client-insights@5.49.2", "", { "dependencies": { "@algolia/client-common": "5.49.2", "@algolia/requester-browser-xhr": "5.49.2", "@algolia/requester-fetch": "5.49.2", "@algolia/requester-node-http": "5.49.2" } }, "sha512-z14wfFs1T3eeYbCArC8pvntAWsPo9f6hnUGoj8IoRUJTwgJiiySECkm8bmmV47/x0oGHfsVn3kBdjMX0yq0sNA=="],
+
+    "@algolia/client-personalization": ["@algolia/client-personalization@5.49.2", "", { "dependencies": { "@algolia/client-common": "5.49.2", "@algolia/requester-browser-xhr": "5.49.2", "@algolia/requester-fetch": "5.49.2", "@algolia/requester-node-http": "5.49.2" } }, "sha512-GpRf7yuuAX93+Qt0JGEJZwgtL0MFdjFO9n7dn8s2pA9mTjzl0Sc5+uTk1VPbIAuf7xhCP9Mve+URGb6J+EYxgA=="],
+
+    "@algolia/client-query-suggestions": ["@algolia/client-query-suggestions@5.49.2", "", { "dependencies": { "@algolia/client-common": "5.49.2", "@algolia/requester-browser-xhr": "5.49.2", "@algolia/requester-fetch": "5.49.2", "@algolia/requester-node-http": "5.49.2" } }, "sha512-HZwApmNkp0DiAjZcLYdQLddcG4Agb88OkojiAHGgcm5DVXobT5uSZ9lmyrbw/tmQBJwgu2CNw4zTyXoIB7YbPA=="],
+
+    "@algolia/client-search": ["@algolia/client-search@5.49.2", "", { "dependencies": { "@algolia/client-common": "5.49.2", "@algolia/requester-browser-xhr": "5.49.2", "@algolia/requester-fetch": "5.49.2", "@algolia/requester-node-http": "5.49.2" } }, "sha512-y1IOpG6OSmTpGg/CT0YBb/EAhR2nsC18QWp9Jy8HO9iGySpcwaTvs5kHa17daP3BMTwWyaX9/1tDTDQshZzXdg=="],
+
+    "@algolia/ingestion": ["@algolia/ingestion@1.49.2", "", { "dependencies": { "@algolia/client-common": "5.49.2", "@algolia/requester-browser-xhr": "5.49.2", "@algolia/requester-fetch": "5.49.2", "@algolia/requester-node-http": "5.49.2" } }, "sha512-YYJRjaZ2bqk923HxE4um7j/Cm3/xoSkF2HC2ZweOF8cXL3sqnlndSUYmCaxHFjNPWLaSHk2IfssX6J/tdKTULw=="],
+
+    "@algolia/monitoring": ["@algolia/monitoring@1.49.2", "", { "dependencies": { "@algolia/client-common": "5.49.2", "@algolia/requester-browser-xhr": "5.49.2", "@algolia/requester-fetch": "5.49.2", "@algolia/requester-node-http": "5.49.2" } }, "sha512-9WgH+Dha39EQQyGKCHlGYnxW/7W19DIrEbCEbnzwAMpGAv1yTWCHMPXHxYa+LcL3eCp2V/5idD1zHNlIKmHRHg=="],
+
+    "@algolia/recommend": ["@algolia/recommend@5.49.2", "", { "dependencies": { "@algolia/client-common": "5.49.2", "@algolia/requester-browser-xhr": "5.49.2", "@algolia/requester-fetch": "5.49.2", "@algolia/requester-node-http": "5.49.2" } }, "sha512-K7Gp5u+JtVYgaVpBxF5rGiM+Ia8SsMdcAJMTDV93rwh00DKNllC19o1g+PwrDjDvyXNrnTEbofzbTs2GLfFyKA=="],
+
+    "@algolia/requester-browser-xhr": ["@algolia/requester-browser-xhr@5.49.2", "", { "dependencies": { "@algolia/client-common": "5.49.2" } }, "sha512-3UhYCcWX6fbtN8ABcxZlhaQEwXFh3CsFtARyyadQShHMPe3mJV9Wel4FpJTa+seugRkbezFz0tt6aPTZSYTBuA=="],
+
+    "@algolia/requester-fetch": ["@algolia/requester-fetch@5.49.2", "", { "dependencies": { "@algolia/client-common": "5.49.2" } }, "sha512-G94VKSGbsr+WjsDDOBe5QDQ82QYgxvpxRGJfCHZBnYKYsy/jv9qGIDb93biza+LJWizQBUtDj7bZzp3QZyzhPQ=="],
+
+    "@algolia/requester-node-http": ["@algolia/requester-node-http@5.49.2", "", { "dependencies": { "@algolia/client-common": "5.49.2" } }, "sha512-UuihBGHafG/ENsrcTGAn5rsOffrCIRuHMOsD85fZGLEY92ate+BMTUqxz60dv5zerh8ZumN4bRm8eW2z9L11jA=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/parser": ["@babel/parser@7.29.0", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
     "@biomejs/biome": ["@biomejs/biome@2.4.7", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.7", "@biomejs/cli-darwin-x64": "2.4.7", "@biomejs/cli-linux-arm64": "2.4.7", "@biomejs/cli-linux-arm64-musl": "2.4.7", "@biomejs/cli-linux-x64": "2.4.7", "@biomejs/cli-linux-x64-musl": "2.4.7", "@biomejs/cli-win32-arm64": "2.4.7", "@biomejs/cli-win32-x64": "2.4.7" }, "bin": { "biome": "bin/biome" } }, "sha512-vXrgcmNGZ4lpdwZSpMf1hWw1aWS6B+SyeSYKTLrNsiUsAdSRN0J4d/7mF3ogJFbIwFFSOL3wT92Zzxia/d5/ng=="],
 
     "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Oo0cF5mHzmvDmTXw8XSjhCia8K6YrZnk7aCS54+/HxyMdZMruMO3nfpDsrlar/EQWe41r1qrwKiCa2QDYHDzWA=="],
@@ -34,13 +81,191 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.7", "", { "os": "win32", "cpu": "x64" }, "sha512-qEpGjSkPC3qX4ycbMUthXvi9CkRq7kZpkqMY1OyhmYlYLnANnooDQ7hDerM8+0NJ+DZKVnsIc07h30XOpt7LtQ=="],
 
+    "@docsearch/css": ["@docsearch/css@3.8.2", "", {}, "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ=="],
+
+    "@docsearch/js": ["@docsearch/js@3.8.2", "", { "dependencies": { "@docsearch/react": "3.8.2", "preact": "^10.0.0" } }, "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ=="],
+
+    "@docsearch/react": ["@docsearch/react@3.8.2", "", { "dependencies": { "@algolia/autocomplete-core": "1.17.7", "@algolia/autocomplete-preset-algolia": "1.17.7", "@docsearch/css": "3.8.2", "algoliasearch": "^5.14.2" }, "peerDependencies": { "@types/react": ">= 16.8.0 < 19.0.0", "react": ">= 16.8.0 < 19.0.0", "react-dom": ">= 16.8.0 < 19.0.0", "search-insights": ">= 1 < 3" }, "optionalPeers": ["@types/react", "react", "react-dom", "search-insights"] }, "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "@gerrit0/mini-shiki": ["@gerrit0/mini-shiki@3.23.0", "", { "dependencies": { "@shikijs/engine-oniguruma": "^3.23.0", "@shikijs/langs": "^3.23.0", "@shikijs/themes": "^3.23.0", "@shikijs/types": "^3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg=="],
+
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
+
+    "@iconify-json/simple-icons": ["@iconify-json/simple-icons@1.2.74", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-yqaohfY6jnYjTVpuTkaBQHrWbdUrQyWXhau0r/0EZiNWYXPX/P8WWwl1DoLH5CbvDjjcWQw5J0zADhgCUklOqA=="],
+
+    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.59.0", "", { "os": "android", "cpu": "arm64" }, "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.59.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.59.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.59.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.59.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.59.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.59.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.59.0", "", { "os": "none", "cpu": "arm64" }, "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.59.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.59.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA=="],
+
+    "@shikijs/core": ["@shikijs/core@2.5.0", "", { "dependencies": { "@shikijs/engine-javascript": "2.5.0", "@shikijs/engine-oniguruma": "2.5.0", "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.4" } }, "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@2.5.0", "", { "dependencies": { "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^3.1.0" } }, "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g=="],
+
+    "@shikijs/langs": ["@shikijs/langs@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg=="],
+
+    "@shikijs/themes": ["@shikijs/themes@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA=="],
+
+    "@shikijs/transformers": ["@shikijs/transformers@2.5.0", "", { "dependencies": { "@shikijs/core": "2.5.0", "@shikijs/types": "2.5.0" } }, "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg=="],
+
+    "@shikijs/types": ["@shikijs/types@2.5.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/linkify-it": ["@types/linkify-it@5.0.0", "", {}, "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q=="],
+
+    "@types/markdown-it": ["@types/markdown-it@14.1.2", "", { "dependencies": { "@types/linkify-it": "^5", "@types/mdurl": "^2" } }, "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/mdurl": ["@types/mdurl@2.0.0", "", {}, "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="],
+
     "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@types/web-bluetooth": ["@types/web-bluetooth@0.0.21", "", {}, "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
+
+    "@vitejs/plugin-vue": ["@vitejs/plugin-vue@5.2.4", "", { "peerDependencies": { "vite": "^5.0.0 || ^6.0.0", "vue": "^3.2.25" } }, "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA=="],
+
+    "@vue/compiler-core": ["@vue/compiler-core@3.5.30", "", { "dependencies": { "@babel/parser": "^7.29.0", "@vue/shared": "3.5.30", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw=="],
+
+    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.30", "", { "dependencies": { "@vue/compiler-core": "3.5.30", "@vue/shared": "3.5.30" } }, "sha512-eCFYESUEVYHhiMuK4SQTldO3RYxyMR/UQL4KdGD1Yrkfdx4m/HYuZ9jSfPdA+nWJY34VWndiYdW/wZXyiPEB9g=="],
+
+    "@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.30", "", { "dependencies": { "@babel/parser": "^7.29.0", "@vue/compiler-core": "3.5.30", "@vue/compiler-dom": "3.5.30", "@vue/compiler-ssr": "3.5.30", "@vue/shared": "3.5.30", "estree-walker": "^2.0.2", "magic-string": "^0.30.21", "postcss": "^8.5.8", "source-map-js": "^1.2.1" } }, "sha512-LqmFPDn89dtU9vI3wHJnwaV6GfTRD87AjWpTWpyrdVOObVtjIuSeZr181z5C4PmVx/V3j2p+0f7edFKGRMpQ5A=="],
+
+    "@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.30", "", { "dependencies": { "@vue/compiler-dom": "3.5.30", "@vue/shared": "3.5.30" } }, "sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA=="],
+
+    "@vue/devtools-api": ["@vue/devtools-api@7.7.9", "", { "dependencies": { "@vue/devtools-kit": "^7.7.9" } }, "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g=="],
+
+    "@vue/devtools-kit": ["@vue/devtools-kit@7.7.9", "", { "dependencies": { "@vue/devtools-shared": "^7.7.9", "birpc": "^2.3.0", "hookable": "^5.5.3", "mitt": "^3.0.1", "perfect-debounce": "^1.0.0", "speakingurl": "^14.0.1", "superjson": "^2.2.2" } }, "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA=="],
+
+    "@vue/devtools-shared": ["@vue/devtools-shared@7.7.9", "", { "dependencies": { "rfdc": "^1.4.1" } }, "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA=="],
+
+    "@vue/reactivity": ["@vue/reactivity@3.5.30", "", { "dependencies": { "@vue/shared": "3.5.30" } }, "sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q=="],
+
+    "@vue/runtime-core": ["@vue/runtime-core@3.5.30", "", { "dependencies": { "@vue/reactivity": "3.5.30", "@vue/shared": "3.5.30" } }, "sha512-e0Z+8PQsUTdwV8TtEsLzUM7SzC7lQwYKePydb7K2ZnmS6jjND+WJXkmmfh/swYzRyfP1EY3fpdesyYoymCzYfg=="],
+
+    "@vue/runtime-dom": ["@vue/runtime-dom@3.5.30", "", { "dependencies": { "@vue/reactivity": "3.5.30", "@vue/runtime-core": "3.5.30", "@vue/shared": "3.5.30", "csstype": "^3.2.3" } }, "sha512-2UIGakjU4WSQ0T4iwDEW0W7vQj6n7AFn7taqZ9Cvm0Q/RA2FFOziLESrDL4GmtI1wV3jXg5nMoJSYO66egDUBw=="],
+
+    "@vue/server-renderer": ["@vue/server-renderer@3.5.30", "", { "dependencies": { "@vue/compiler-ssr": "3.5.30", "@vue/shared": "3.5.30" }, "peerDependencies": { "vue": "3.5.30" } }, "sha512-v+R34icapydRwbZRD0sXwtHqrQJv38JuMB4JxbOxd8NEpGLny7cncMp53W9UH/zo4j8eDHjQ1dEJXwzFQknjtQ=="],
+
+    "@vue/shared": ["@vue/shared@3.5.30", "", {}, "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ=="],
+
+    "@vueuse/core": ["@vueuse/core@12.8.2", "", { "dependencies": { "@types/web-bluetooth": "^0.0.21", "@vueuse/metadata": "12.8.2", "@vueuse/shared": "12.8.2", "vue": "^3.5.13" } }, "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ=="],
+
+    "@vueuse/integrations": ["@vueuse/integrations@12.8.2", "", { "dependencies": { "@vueuse/core": "12.8.2", "@vueuse/shared": "12.8.2", "vue": "^3.5.13" }, "peerDependencies": { "async-validator": "^4", "axios": "^1", "change-case": "^5", "drauu": "^0.4", "focus-trap": "^7", "fuse.js": "^7", "idb-keyval": "^6", "jwt-decode": "^4", "nprogress": "^0.2", "qrcode": "^1.5", "sortablejs": "^1", "universal-cookie": "^7" }, "optionalPeers": ["async-validator", "axios", "change-case", "drauu", "focus-trap", "fuse.js", "idb-keyval", "jwt-decode", "nprogress", "qrcode", "sortablejs", "universal-cookie"] }, "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g=="],
+
+    "@vueuse/metadata": ["@vueuse/metadata@12.8.2", "", {}, "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A=="],
+
+    "@vueuse/shared": ["@vueuse/shared@12.8.2", "", { "dependencies": { "vue": "^3.5.13" } }, "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
@@ -48,7 +273,17 @@
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
+    "algoliasearch": ["algoliasearch@5.49.2", "", { "dependencies": { "@algolia/abtesting": "1.15.2", "@algolia/client-abtesting": "5.49.2", "@algolia/client-analytics": "5.49.2", "@algolia/client-common": "5.49.2", "@algolia/client-insights": "5.49.2", "@algolia/client-personalization": "5.49.2", "@algolia/client-query-suggestions": "5.49.2", "@algolia/client-search": "5.49.2", "@algolia/ingestion": "1.49.2", "@algolia/monitoring": "1.49.2", "@algolia/recommend": "5.49.2", "@algolia/requester-browser-xhr": "5.49.2", "@algolia/requester-fetch": "5.49.2", "@algolia/requester-node-http": "5.49.2" } }, "sha512-1K0wtDaRONwfhL4h8bbJ9qTjmY6rhGgRvvagXkMBsAOMNr+3Q2SffHECh9DIuNVrMA1JwA0zCwhyepgBZVakng=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "birpc": ["birpc@2.9.0", "", {}, "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw=="],
+
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
@@ -58,6 +293,14 @@
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
     "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
@@ -66,19 +309,31 @@
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
+    "copy-anything": ["copy-anything@4.0.5", "", { "dependencies": { "is-what": "^5.2.0" } }, "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA=="],
+
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
+    "emoji-regex-xs": ["emoji-regex-xs@1.0.0", "", {}, "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg=="],
+
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -86,7 +341,11 @@
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
+    "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
@@ -104,9 +363,13 @@
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
+    "focus-trap": ["focus-trap@7.8.0", "", { "dependencies": { "tabbable": "^6.4.0" } }, "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA=="],
+
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -120,7 +383,15 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
     "hono": ["hono@4.12.8", "", {}, "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A=="],
+
+    "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
@@ -134,6 +405,8 @@
 
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
+    "is-what": ["is-what@5.5.0", "", {}, "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw=="],
+
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jose": ["jose@6.2.1", "", {}, "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw=="],
@@ -142,17 +415,49 @@
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
+    "linkify-it": ["linkify-it@5.0.0", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
+
+    "lunr": ["lunr@2.3.9", "", {}, "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "mark.js": ["mark.js@8.11.1", "", {}, "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ=="],
+
+    "markdown-it": ["markdown-it@14.1.1", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.4.0", "linkify-it": "^5.0.0", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
+
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
+    "minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "minisearch": ["minisearch@7.2.0", "", {}, "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg=="],
+
+    "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
@@ -164,15 +469,29 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
+    "oniguruma-to-es": ["oniguruma-to-es@3.1.1", "", { "dependencies": { "emoji-regex-xs": "^1.0.0", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ=="],
+
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
+    "perfect-debounce": ["perfect-debounce@1.0.0", "", {}, "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
+    "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+
+    "preact": ["preact@10.29.0", "", {}, "sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg=="],
+
+    "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
     "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
 
@@ -180,11 +499,23 @@
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
+
+    "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "search-insights": ["search-insights@2.17.3", "", {}, "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ=="],
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
@@ -196,6 +527,8 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "shiki": ["shiki@2.5.0", "", { "dependencies": { "@shikijs/core": "2.5.0", "@shikijs/engine-javascript": "2.5.0", "@shikijs/engine-oniguruma": "2.5.0", "@shikijs/langs": "2.5.0", "@shikijs/themes": "2.5.0", "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ=="],
+
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 
     "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
@@ -204,26 +537,88 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "speakingurl": ["speakingurl@14.0.1", "", {}, "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
+    "superjson": ["superjson@2.2.6", "", { "dependencies": { "copy-anything": "^4" } }, "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA=="],
+
+    "tabbable": ["tabbable@6.4.0", "", {}, "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "typedoc": ["typedoc@0.28.17", "", { "dependencies": { "@gerrit0/mini-shiki": "^3.17.0", "lunr": "^2.3.9", "markdown-it": "^14.1.0", "minimatch": "^9.0.5", "yaml": "^2.8.1" }, "peerDependencies": { "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x" }, "bin": { "typedoc": "bin/typedoc" } }, "sha512-ZkJ2G7mZrbxrKxinTQMjFqsCoYY6a5Luwv2GKbTnBCEgV2ihYm5CflA9JnJAwH0pZWavqfYxmDkFHPt4yx2oDQ=="],
+
+    "typedoc-plugin-markdown": ["typedoc-plugin-markdown@4.10.0", "", { "peerDependencies": { "typedoc": "0.28.x" } }, "sha512-psrg8Rtnv4HPWCsoxId+MzEN8TVK5jeKCnTbnGAbTBqcDapR9hM41bJT/9eAyKn9C2MDG9Qjh3MkltAYuLDoXg=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
+    "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
+
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
+    "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "vitepress": ["vitepress@1.6.4", "", { "dependencies": { "@docsearch/css": "3.8.2", "@docsearch/js": "3.8.2", "@iconify-json/simple-icons": "^1.2.21", "@shikijs/core": "^2.1.0", "@shikijs/transformers": "^2.1.0", "@shikijs/types": "^2.1.0", "@types/markdown-it": "^14.1.2", "@vitejs/plugin-vue": "^5.2.1", "@vue/devtools-api": "^7.7.0", "@vue/shared": "^3.5.13", "@vueuse/core": "^12.4.0", "@vueuse/integrations": "^12.4.0", "focus-trap": "^7.6.4", "mark.js": "8.11.1", "minisearch": "^7.1.1", "shiki": "^2.1.0", "vite": "^5.4.14", "vue": "^3.5.13" }, "peerDependencies": { "markdown-it-mathjax3": "^4", "postcss": "^8" }, "optionalPeers": ["markdown-it-mathjax3", "postcss"], "bin": { "vitepress": "bin/vitepress.js" } }, "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg=="],
+
+    "vue": ["vue@3.5.30", "", { "dependencies": { "@vue/compiler-dom": "3.5.30", "@vue/compiler-sfc": "3.5.30", "@vue/runtime-dom": "3.5.30", "@vue/server-renderer": "3.5.30", "@vue/shared": "3.5.30" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
+    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
+
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@gerrit0/mini-shiki/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
+    "@shikijs/core/@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@2.5.0", "", { "dependencies": { "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw=="],
+
+    "@shikijs/engine-oniguruma/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
+    "@shikijs/langs/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
+    "@shikijs/themes/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
+    "@vue/compiler-core/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "shiki/@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@2.5.0", "", { "dependencies": { "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw=="],
+
+    "shiki/@shikijs/langs": ["@shikijs/langs@2.5.0", "", { "dependencies": { "@shikijs/types": "2.5.0" } }, "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w=="],
+
+    "shiki/@shikijs/themes": ["@shikijs/themes@2.5.0", "", { "dependencies": { "@shikijs/types": "2.5.0" } }, "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw=="],
   }
 }

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitepress";
 export default defineConfig({
   title: "builtwith-api",
   description: "A typed TypeScript wrapper for the BuiltWith API — library, CLI, and MCP server",
-  base: "/builtwith-api/",
+  base: "/",
 
   head: [
     ["link", { rel: "preconnect", href: "https://fonts.googleapis.com" }],

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -25,33 +25,127 @@ export default defineConfig({
       { text: "API Reference", link: "/api/" },
     ],
 
-    sidebar: [
-      {
-        text: "Getting Started",
-        items: [
-          { text: "Introduction", link: "/guide/" },
-          { text: "Installation", link: "/guide/installation" },
-        ],
-      },
-      {
-        text: "Usage",
-        items: [
-          { text: "Library", link: "/guide/library" },
-          { text: "CLI", link: "/cli" },
-          { text: "MCP Server", link: "/mcp" },
-        ],
-      },
-      {
-        text: "API Reference",
-        link: "/api/",
-      },
-    ],
+    sidebar: {
+      "/guide/library": [
+        {
+          text: "Getting Started",
+          items: [
+            { text: "Installation", link: "/guide/installation" },
+            { text: "Quick Start", link: "/guide/library", },
+            { text: "Configuration", link: "/guide/library#response-format" },
+          ],
+        },
+        {
+          text: "Methods",
+          items: [
+            { text: "free()", link: "/guide/library#free-lookup" },
+            { text: "domain()", link: "/guide/library#domain-lookup-params" },
+            { text: "domainLive()", link: "/guide/library#domainlive-lookup" },
+            { text: "lists()", link: "/guide/library#lists-technology-params" },
+            { text: "relationships()", link: "/guide/library#relationships-lookup" },
+            { text: "keywords()", link: "/guide/library#keywords-lookup" },
+            { text: "trends()", link: "/guide/library#trends-technology-params" },
+            { text: "trust()", link: "/guide/library#trust-lookup-params" },
+            { text: "companyToUrl()", link: "/guide/library#companytourl-companyname-params" },
+            { text: "tags()", link: "/guide/library#tags-lookup" },
+            { text: "recommendations()", link: "/guide/library#recommendations-lookup" },
+            { text: "redirects()", link: "/guide/library#redirects-lookup" },
+            { text: "product()", link: "/guide/library#product-query" },
+          ],
+        },
+      ],
+      "/cli": [
+        {
+          text: "Getting Started",
+          items: [
+            { text: "Installation", link: "/cli#installation" },
+            { text: "Authentication", link: "/cli#authentication" },
+            { text: "Usage", link: "/cli#examples" },
+          ],
+        },
+        {
+          text: "Commands",
+          items: [
+            { text: "free", link: "/cli#free" },
+            { text: "domain", link: "/cli#domain" },
+            { text: "domainLive", link: "/cli#domainlive" },
+            { text: "lists", link: "/cli#lists" },
+            { text: "trust", link: "/cli#trust" },
+            { text: "trends", link: "/cli#trends" },
+            { text: "keywords", link: "/cli#keywords" },
+            { text: "relationships", link: "/cli#relationships" },
+            { text: "companyToUrl", link: "/cli#companytourl" },
+            { text: "tags", link: "/cli#tags" },
+            { text: "recommendations", link: "/cli#recommendations" },
+            { text: "redirects", link: "/cli#redirects" },
+            { text: "product", link: "/cli#product" },
+          ],
+        },
+        {
+          text: "Options",
+          items: [
+            { text: "--help", link: "/cli#help" },
+            { text: "--version", link: "/cli#help" },
+            { text: "--api-key", link: "/cli#authentication" },
+          ],
+        },
+      ],
+      "/mcp": [
+        {
+          text: "Setup",
+          items: [
+            { text: "Claude Desktop", link: "/mcp#claude-desktop" },
+            { text: "Cursor", link: "/mcp#cursor" },
+            { text: "Claude Code", link: "/mcp#claude-code" },
+            { text: "Other Clients", link: "/mcp#other-clients" },
+          ],
+        },
+        {
+          text: "Tools",
+          items: [
+            { text: "builtwith_free", link: "/mcp#available-tools" },
+            { text: "builtwith_domain", link: "/mcp#available-tools" },
+            { text: "builtwith_lists", link: "/mcp#available-tools" },
+            { text: "builtwith_trust", link: "/mcp#available-tools" },
+            { text: "builtwith_trends", link: "/mcp#available-tools" },
+            { text: "builtwith_keywords", link: "/mcp#available-tools" },
+          ],
+        },
+        {
+          text: "Testing",
+          items: [
+            { text: "MCP Inspector", link: "/mcp#testing" },
+          ],
+        },
+      ],
+      "/": [
+        {
+          text: "Getting Started",
+          items: [
+            { text: "Introduction", link: "/guide/" },
+            { text: "Installation", link: "/guide/installation" },
+          ],
+        },
+        {
+          text: "Usage",
+          items: [
+            { text: "Library", link: "/guide/library" },
+            { text: "CLI", link: "/cli" },
+            { text: "MCP Server", link: "/mcp" },
+          ],
+        },
+        {
+          text: "API Reference",
+          link: "/api/",
+        },
+      ],
+    },
 
     socialLinks: [{ icon: "github", link: "https://github.com/zcaceres/builtwith-api" }],
 
     footer: {
       message: "Released under the MIT License.",
-      copyright: 'Built by <a href="https://zach.dev">zach.dev</a>. Not affiliated with <a href="https://builtwith.com">builtwith.com</a>.',
+      copyright: 'Built by <a href="https://zach.dev" target="_blank" rel="noopener">zach.dev</a>. Not affiliated with <a href="https://builtwith.com" target="_blank" rel="noopener">builtwith.com</a>.',
     },
   },
 });

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,0 +1,56 @@
+import { defineConfig } from "vitepress";
+
+export default defineConfig({
+  title: "builtwith-api",
+  description: "Typed Node.js client, CLI, and MCP server for the BuiltWith API",
+  base: "/builtwith-api/",
+
+  head: [
+    ["link", { rel: "preconnect", href: "https://fonts.googleapis.com" }],
+    ["link", { rel: "preconnect", href: "https://fonts.gstatic.com", crossorigin: "" }],
+    [
+      "link",
+      {
+        href: "https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap",
+        rel: "stylesheet",
+      },
+    ],
+  ],
+
+  themeConfig: {
+    nav: [
+      { text: "Guide", link: "/guide/" },
+      { text: "CLI", link: "/cli" },
+      { text: "MCP", link: "/mcp" },
+      { text: "API Reference", link: "/api/" },
+    ],
+
+    sidebar: [
+      {
+        text: "Getting Started",
+        items: [
+          { text: "Introduction", link: "/guide/" },
+          { text: "Installation", link: "/guide/installation" },
+        ],
+      },
+      {
+        text: "Usage",
+        items: [
+          { text: "Library", link: "/guide/library" },
+          { text: "CLI", link: "/cli" },
+          { text: "MCP Server", link: "/mcp" },
+        ],
+      },
+      {
+        text: "API Reference",
+        link: "/api/",
+      },
+    ],
+
+    socialLinks: [{ icon: "github", link: "https://github.com/zcaceres/builtwith-api" }],
+
+    footer: {
+      message: "Released under the MIT License.",
+    },
+  },
+});

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitepress";
 
 export default defineConfig({
   title: "builtwith-api",
-  description: "Typed Node.js client, CLI, and MCP server for the BuiltWith API",
+  description: "A typed TypeScript wrapper for the BuiltWith API — library, CLI, and MCP server",
   base: "/builtwith-api/",
 
   head: [
@@ -19,9 +19,9 @@ export default defineConfig({
 
   themeConfig: {
     nav: [
-      { text: "Guide", link: "/guide/" },
+      { text: "Library", link: "/guide/library" },
       { text: "CLI", link: "/cli" },
-      { text: "MCP", link: "/mcp" },
+      { text: "MCP Server", link: "/mcp" },
       { text: "API Reference", link: "/api/" },
     ],
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
 
     footer: {
       message: "Released under the MIT License.",
+      copyright: 'Built by <a href="https://zach.dev">zach.dev</a>. Not affiliated with <a href="https://builtwith.com">builtwith.com</a>.',
     },
   },
 });

--- a/docs/.vitepress/theme/HomePage.vue
+++ b/docs/.vitepress/theme/HomePage.vue
@@ -1,0 +1,253 @@
+<template>
+  <div class="home-page">
+    <!-- Hero -->
+    <section class="hero">
+      <div class="hero-inner">
+        <div class="hero-badge">
+          <span class="version-tag">V3.1</span>
+          <span class="tech-tags">TypeScript / ESM-only / Zero config</span>
+        </div>
+        <h1 class="hero-title">builtwith-api</h1>
+        <p class="hero-tagline">
+          A typed TypeScript wrapper for the BuiltWith API. Query technology
+          data from your code, your terminal, or your AI assistant.
+        </p>
+        <div class="hero-actions">
+          <div class="install-pill">
+            <span class="dollar">$</span>
+            <span>npm install builtwith-api</span>
+          </div>
+          <a class="btn btn-outline" href="/builtwith-api/guide/">Get Started</a>
+          <a class="btn btn-outline" href="/builtwith-api/api/">API Reference</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Features -->
+    <section class="features">
+      <div class="features-inner">
+        <div class="features-header">
+          <span class="features-label">THREE WAYS TO USE IT</span>
+          <h2 class="features-title">One package, three interfaces.</h2>
+        </div>
+        <div class="features-grid">
+          <a class="feature-card" href="/builtwith-api/guide/library">
+            <span class="feature-tag">LIBRARY</span>
+            <h3>TypeScript SDK</h3>
+            <p>
+              Import createClient and call any of 13 endpoints. Typed responses
+              validated with Zod — no guessing at API shapes.
+            </p>
+            <div class="feature-code">const data = await client.free("google.com")</div>
+          </a>
+          <a class="feature-card" href="/builtwith-api/cli">
+            <span class="feature-tag">CLI</span>
+            <h3>Command Line</h3>
+            <p>
+              Query the BuiltWith API from your terminal. Supports all 13 methods
+              with flags for every parameter.
+            </p>
+            <div class="feature-code">$ builtwith domain example.com</div>
+          </a>
+          <a class="feature-card" href="/builtwith-api/mcp">
+            <span class="feature-tag">MCP</span>
+            <h3>AI Assistant</h3>
+            <p>
+              Give Claude, Cursor, or any MCP-compatible tool direct access to
+              BuiltWith lookups. Just add the config and ask.
+            </p>
+            <div class="feature-code">npx -p builtwith-api builtwith-mcp</div>
+          </a>
+        </div>
+      </div>
+    </section>
+
+  </div>
+</template>
+
+<style scoped>
+.home-page {
+  max-width: 100%;
+}
+
+/* ── Hero ── */
+.hero {
+  padding: 80px 24px 64px;
+  max-width: 960px;
+  margin: 0 auto;
+}
+.hero-inner {
+  max-width: 640px;
+}
+.hero-badge {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+.version-tag {
+  background: var(--vp-c-brand-1);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 2px 10px;
+  border-radius: 12px;
+  letter-spacing: 0.02em;
+}
+.tech-tags {
+  color: var(--vp-c-text-2);
+  font-size: 14px;
+}
+.hero-title {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 72px;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1;
+  margin: 0 0 20px;
+  background: var(--vp-home-hero-name-background);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.hero-tagline {
+  font-size: 18px;
+  line-height: 1.6;
+  color: var(--vp-c-text-2);
+  margin: 0 0 40px;
+  max-width: 480px;
+}
+.hero-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.install-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--vp-c-text-1);
+  color: var(--vp-c-bg);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 14px;
+  padding: 10px 20px;
+  border-radius: 8px;
+  user-select: all;
+}
+.install-pill .dollar {
+  opacity: 0.5;
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  text-decoration: none;
+  transition: border-color 0.2s, color 0.2s;
+}
+.btn-outline {
+  border: 1px solid var(--vp-c-divider);
+  color: var(--vp-c-text-1);
+  background: transparent;
+}
+.btn-outline:hover {
+  border-color: var(--vp-c-text-2);
+}
+
+/* ── Features ── */
+.features {
+  padding: 0 24px 80px;
+  max-width: 960px;
+  margin: 0 auto;
+}
+.features-header {
+  margin-bottom: 32px;
+}
+.features-label {
+  display: block;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vp-c-brand-1);
+  margin-bottom: 8px;
+}
+.features-title {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 32px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0;
+  color: var(--vp-c-text-1);
+}
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+.feature-card {
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  padding: 28px 24px 24px;
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.2s;
+}
+.feature-card:hover {
+  border-color: var(--vp-c-text-3);
+}
+.feature-tag {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vp-c-brand-1);
+  margin-bottom: 4px;
+}
+.feature-card h3 {
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 20px;
+  font-weight: 700;
+  margin: 0 0 12px;
+  color: var(--vp-c-text-1);
+}
+.feature-card p {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--vp-c-text-2);
+  margin: 0;
+  flex: 1;
+}
+.feature-code {
+  margin-top: 20px;
+  background: var(--vp-c-text-1);
+  color: var(--vp-c-bg);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 13px;
+  padding: 10px 14px;
+  border-radius: 8px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Responsive ── */
+@media (max-width: 768px) {
+  .hero-title {
+    font-size: 48px;
+  }
+  .features-grid {
+    grid-template-columns: 1fr;
+  }
+  .hero-actions {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/HomePage.vue
+++ b/docs/.vitepress/theme/HomePage.vue
@@ -17,8 +17,8 @@
             <span class="dollar">$</span>
             <span>npm install builtwith-api</span>
           </div>
-          <a class="btn btn-outline" href="/builtwith-api/guide/">Get Started</a>
-          <a class="btn btn-outline" href="/builtwith-api/api/">API Reference</a>
+          <a class="btn btn-outline" href="/guide/">Get Started</a>
+          <a class="btn btn-outline" href="/api/">API Reference</a>
         </div>
       </div>
     </section>
@@ -31,7 +31,7 @@
           <h2 class="features-title">One package, three interfaces.</h2>
         </div>
         <div class="features-grid">
-          <a class="feature-card" href="/builtwith-api/guide/library">
+          <a class="feature-card" href="/guide/library">
             <span class="feature-tag">LIBRARY</span>
             <h3>TypeScript SDK</h3>
             <p>
@@ -40,7 +40,7 @@
             </p>
             <div class="feature-code">const data = await client.free("google.com")</div>
           </a>
-          <a class="feature-card" href="/builtwith-api/cli">
+          <a class="feature-card" href="/cli">
             <span class="feature-tag">CLI</span>
             <h3>Command Line</h3>
             <p>
@@ -49,7 +49,7 @@
             </p>
             <div class="feature-code">$ builtwith domain example.com</div>
           </a>
-          <a class="feature-card" href="/builtwith-api/mcp">
+          <a class="feature-card" href="/mcp">
             <span class="feature-tag">MCP</span>
             <h3>AI Assistant</h3>
             <p>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -32,6 +32,7 @@
   --vp-c-text-2: #8A8A80;
   --vp-c-text-3: #5A5A54;
   --vp-c-divider: #3a3a36;
+  --vp-home-hero-name-background: linear-gradient(135deg, #F0EFEB 40%, #C45D3E);
 }
 
 /* Headings use Space Grotesk */

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,69 @@
+:root {
+  /* Terracotta accent */
+  --vp-c-brand-1: #C45D3E;
+  --vp-c-brand-2: #b55235;
+  --vp-c-brand-3: #a8482d;
+  --vp-c-brand-soft: rgba(196, 93, 62, 0.12);
+
+  /* Typography */
+  --vp-font-family-base: "Inter", sans-serif;
+  --vp-font-family-mono: "JetBrains Mono", monospace;
+
+  /* Warm palette overrides */
+  --vp-c-bg: #FAFAF8;
+  --vp-c-bg-soft: #F0EFEB;
+  --vp-c-bg-mute: #E0DFD8;
+  --vp-c-text-1: #1A1A1A;
+  --vp-c-text-2: #5A5A54;
+  --vp-c-text-3: #8A8A80;
+  --vp-c-divider: #E0DFD8;
+
+  /* Home hero gradient */
+  --vp-home-hero-name-color: transparent;
+  --vp-home-hero-name-background: linear-gradient(135deg, #1A1A1A 40%, #C45D3E);
+  --vp-home-hero-image-background-image: none;
+}
+
+.dark {
+  --vp-c-bg: #1A1A1A;
+  --vp-c-bg-soft: #2a2a28;
+  --vp-c-bg-mute: #3a3a36;
+  --vp-c-text-1: #F0EFEB;
+  --vp-c-text-2: #8A8A80;
+  --vp-c-text-3: #5A5A54;
+  --vp-c-divider: #3a3a36;
+}
+
+/* Headings use Space Grotesk */
+.vp-doc h1,
+.vp-doc h2,
+.vp-doc h3,
+.vp-doc h4,
+.VPHero .name,
+.VPHero .text {
+  font-family: "Space Grotesk", sans-serif !important;
+  letter-spacing: -0.02em;
+}
+
+/* Hero title */
+.VPHero .name {
+  font-weight: 700;
+}
+
+/* Code blocks */
+.vp-doc div[class*="language-"] {
+  border-radius: 8px;
+  border: 1px solid var(--vp-c-divider);
+}
+
+/* Inline code */
+.vp-doc :not(pre) > code {
+  color: var(--vp-c-brand-1);
+  background: var(--vp-c-brand-soft);
+}
+
+/* Custom badge colors */
+.VPBadge.tip {
+  background-color: var(--vp-c-brand-soft);
+  color: var(--vp-c-brand-1);
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,4 @@
+import DefaultTheme from "vitepress/theme";
+import "./custom.css";
+
+export default DefaultTheme;

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,4 +1,10 @@
 import DefaultTheme from "vitepress/theme";
+import HomePage from "./HomePage.vue";
 import "./custom.css";
 
-export default DefaultTheme;
+export default {
+  extends: DefaultTheme,
+  enhanceApp({ app }) {
+    app.component("HomePage", HomePage);
+  },
+};

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,7 +9,7 @@ The `builtwith` CLI lets you query the BuiltWith API from your terminal. Output 
 npm install -g builtwith-api
 
 # Or run without installing
-npx builtwith-api free example.com --api-key YOUR_KEY
+npx --package builtwith-api builtwith free example.com --api-key YOUR_KEY
 ```
 
 Standalone binaries are also available on the [GitHub Releases](https://github.com/zcaceres/builtwith-api/releases) page.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,175 @@
+# CLI
+
+The `builtwith` CLI lets you query the BuiltWith API from your terminal. Output is JSON, ready for piping to `jq`, scripts, or dashboards.
+
+## Installation
+
+```bash
+# Via npm (global)
+npm install -g builtwith-api
+
+# Or run without installing
+npx builtwith-api free example.com --api-key YOUR_KEY
+```
+
+Standalone binaries are also available on the [GitHub Releases](https://github.com/zcaceres/builtwith-api/releases) page.
+
+## Authentication
+
+Set your API key as an environment variable:
+
+```bash
+export BUILTWITH_API_KEY=your-key-here
+```
+
+Or pass it with each command:
+
+```bash
+builtwith free example.com --api-key your-key-here
+```
+
+## Commands
+
+### `free`
+
+Basic technology profile for a domain.
+
+```bash
+builtwith free example.com
+```
+
+### `domain`
+
+Detailed technology profile with optional filters.
+
+```bash
+builtwith domain example.com
+builtwith domain example.com --onlyLiveTechnologies --hideAll
+builtwith domain "example.com,other.com"
+```
+
+| Flag | Description |
+|------|-------------|
+| `--hideAll` | Hide description text and links |
+| `--hideDescriptionAndLinks` | Hide description and links only |
+| `--onlyLiveTechnologies` | Only return live technologies |
+| `--noMetaData` | Exclude metadata |
+| `--noAttributeData` | Exclude attribute data |
+| `--noPII` | Exclude personally identifiable information |
+| `--firstDetectedRange` | Filter by first detected date range |
+| `--lastDetectedRange` | Filter by last detected date range |
+
+### `domainLive`
+
+Real-time technology scan.
+
+```bash
+builtwith domainLive example.com
+```
+
+### `lists`
+
+List domains using a technology.
+
+```bash
+builtwith lists Shopify
+builtwith lists React --since 2024-01-01 --includeMetaData
+```
+
+### `trends`
+
+Technology adoption trends.
+
+```bash
+builtwith trends jQuery
+builtwith trends React --date 2024-06
+```
+
+### `relationships`
+
+Find related domains via shared identifiers.
+
+```bash
+builtwith relationships example.com
+```
+
+### `keywords`
+
+Get SEO keywords for a domain.
+
+```bash
+builtwith keywords example.com
+```
+
+### `trust`
+
+Domain trust and verification score.
+
+```bash
+builtwith trust example.com
+builtwith trust example.com --words "shop,buy" --live
+```
+
+### `companyToUrl`
+
+Find domains associated with a company.
+
+```bash
+builtwith companyToUrl Google
+builtwith companyToUrl Google --tld com --amount 5
+```
+
+### `tags`
+
+Tracking and analytics tags.
+
+```bash
+builtwith tags example.com
+```
+
+### `recommendations`
+
+Technology recommendations.
+
+```bash
+builtwith recommendations example.com
+```
+
+### `redirects`
+
+Redirect chains (inbound and outbound).
+
+```bash
+builtwith redirects example.com
+```
+
+### `product`
+
+Search e-commerce products.
+
+```bash
+builtwith product "wireless headphones"
+```
+
+## Piping and scripting
+
+```bash
+# Extract technology names with jq
+builtwith free stripe.com | jq '.groups[].name'
+
+# Save to file
+builtwith domain example.com > profile.json
+
+# Process multiple domains
+for domain in stripe.com shopify.com vercel.com; do
+  builtwith free "$domain" > "${domain}.json"
+done
+```
+
+## Help
+
+```bash
+builtwith --help
+builtwith domain --help
+builtwith --version
+```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
-# CLI
+# Command Line
 
-The `builtwith` CLI lets you query the BuiltWith API from your terminal. Output is JSON, ready for piping to `jq`, scripts, or dashboards.
+Query the BuiltWith API from your terminal. All 13 methods with flags for every parameter.
 
 ## Installation
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -151,6 +151,48 @@ Search e-commerce products.
 builtwith product "wireless headphones"
 ```
 
+## Examples
+
+**Free lookup**
+```bash
+builtwith free google.com
+```
+
+**Domain with flags**
+```bash
+builtwith domain example.com \
+  --onlyLiveTechnologies
+```
+
+**Multi-domain lookup**
+```bash
+builtwith domain "a.com,b.com"
+```
+
+**Technology lists**
+```bash
+builtwith lists Shopify \
+  --since 2024-01-01
+```
+
+## All Commands
+
+| Command | Description |
+|---------|-------------|
+| `free` | Basic technology profile for a domain |
+| `domain` | Detailed technology profile with spend history |
+| `domainLive` | Real-time technology scan |
+| `lists` | List domains using a specific technology |
+| `trust` | Trust and verification score |
+| `trends` | Technology adoption trends |
+| `keywords` | Get keywords for domains |
+| `relationships` | Find related domains via shared identifiers |
+| `companyToUrl` | Find domains for a company name |
+| `tags` | Tracking and analytics tags |
+| `recommendations` | Technology recommendations |
+| `redirects` | Redirect chain history |
+| `product` | E-commerce product search |
+
 ## Piping and scripting
 
 ```bash

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -37,7 +37,7 @@ Connect BuiltWith to AI tools that support the Model Context Protocol.
   "mcpServers": {
     "builtwith": {
       "command": "npx",
-      "args": ["-y", "builtwith-api"],
+      "args": ["-y", "--package", "builtwith-api", "builtwith-mcp"],
       "env": { "BUILTWITH_API_KEY": "your-key" }
     }
   }

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,0 +1,50 @@
+# Introduction
+
+**builtwith-api** is a typed wrapper around the [BuiltWith API](https://api.builtwith.com/) that works as a library, CLI, and MCP server.
+
+## What is BuiltWith?
+
+BuiltWith tracks the technologies used by websites across the internet — frameworks, analytics, CMS platforms, e-commerce tools, CDNs, and more. Their API gives you programmatic access to this intelligence.
+
+## Three ways to use it
+
+### Library
+
+Import `createClient` and call methods directly. Responses are validated with Zod and fully typed.
+
+```ts
+import { createClient } from "builtwith-api";
+
+const client = createClient(process.env.BUILTWITH_API_KEY!);
+const profile = await client.free("example.com");
+```
+
+### CLI
+
+Query from your terminal. Output is JSON, ready for piping.
+
+```bash
+builtwith free example.com
+builtwith domain example.com --onlyLiveTechnologies
+```
+
+### MCP Server
+
+Connect BuiltWith to AI tools that support the Model Context Protocol.
+
+```json
+{
+  "mcpServers": {
+    "builtwith": {
+      "command": "npx",
+      "args": ["-y", "builtwith-api"],
+      "env": { "BUILTWITH_API_KEY": "your-key" }
+    }
+  }
+}
+```
+
+## Requirements
+
+- Node.js 18+
+- A [BuiltWith API key](https://api.builtwith.com/)

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,0 +1,56 @@
+# Installation
+
+## npm / yarn / pnpm
+
+```bash
+npm install builtwith-api
+```
+
+```bash
+yarn add builtwith-api
+```
+
+```bash
+pnpm add builtwith-api
+```
+
+## Bun
+
+```bash
+bun add builtwith-api
+```
+
+## CLI (no install)
+
+Run the CLI directly with `npx`:
+
+```bash
+npx builtwith-api free example.com --api-key YOUR_KEY
+```
+
+Or install globally:
+
+```bash
+npm install -g builtwith-api
+builtwith free example.com
+```
+
+## Standalone binaries
+
+Pre-compiled binaries are available on the [GitHub Releases](https://github.com/zcaceres/builtwith-api/releases) page for:
+
+- Linux x64 / ARM64
+- macOS x64 / ARM64 (Apple Silicon)
+- Windows x64
+
+## API Key
+
+You need a BuiltWith API key. Get one at [api.builtwith.com](https://api.builtwith.com/).
+
+Set it as an environment variable:
+
+```bash
+export BUILTWITH_API_KEY=your-key-here
+```
+
+Or pass it directly via `--api-key` (CLI/MCP) or as the first argument to `createClient()` (library).

--- a/docs/guide/library.md
+++ b/docs/guide/library.md
@@ -1,0 +1,200 @@
+# Library Usage
+
+## Quick Start
+
+```ts
+import { createClient } from "builtwith-api";
+
+const client = createClient(process.env.BUILTWITH_API_KEY!);
+```
+
+All client methods return typed, Zod-validated responses. If the API returns unexpected data, a `ZodError` is thrown with details about which fields failed validation.
+
+## Methods
+
+### `free(lookup)`
+
+Basic technology profile for a single domain. Available on free API plans.
+
+```ts
+const profile = await client.free("stripe.com");
+// profile.domain, profile.groups, profile.first, profile.last
+```
+
+### `domain(lookup, params?)`
+
+Detailed technology profile with metadata, spend history, and attributes.
+
+```ts
+// Single domain
+const result = await client.domain("example.com");
+
+// Multiple domains (up to 16)
+const results = await client.domain(["example.com", "stripe.com"]);
+
+// With filters
+const filtered = await client.domain("example.com", {
+  onlyLiveTechnologies: true,
+  hideAll: true,
+  noPII: true,
+});
+```
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `hideAll` | `boolean` | Hide description text and links |
+| `hideDescriptionAndLinks` | `boolean` | Hide description and links only |
+| `onlyLiveTechnologies` | `boolean` | Only return currently live technologies |
+| `noMetaData` | `boolean` | Exclude company metadata |
+| `noAttributeData` | `boolean` | Exclude attribute data |
+| `noPII` | `boolean` | Exclude personally identifiable information |
+| `firstDetectedRange` | `string` | Filter by first detected date range |
+| `lastDetectedRange` | `string` | Filter by last detected date range |
+
+### `domainLive(lookup)`
+
+Real-time technology scan. Same response shape as `domain()`, but scans the site live.
+
+```ts
+const live = await client.domainLive("example.com");
+```
+
+### `lists(technology, params?)`
+
+Find domains using a specific technology.
+
+```ts
+const shopifySites = await client.lists("Shopify");
+
+// With pagination
+const page2 = await client.lists("Shopify", {
+  offset: shopifySites.NextOffset,
+});
+
+// Filter by date
+const recent = await client.lists("React", {
+  since: "2024-01-01",
+  includeMetaData: true,
+});
+```
+
+### `trends(technology, params?)`
+
+Technology adoption trends and coverage data.
+
+```ts
+const trends = await client.trends("jQuery");
+// trends.Tech.coverage.live, trends.Tech.coverage.ten_k, etc.
+```
+
+### `relationships(lookup)`
+
+Find related domains that share identifiers (analytics IDs, ad accounts, etc.).
+
+```ts
+const related = await client.relationships("example.com");
+// related.Relationships[].Identifiers[].Matches[]
+```
+
+### `keywords(lookup)`
+
+Get SEO keywords associated with domains.
+
+```ts
+const kw = await client.keywords("example.com");
+// kw.Keywords[].Keywords[]
+```
+
+### `trust(lookup, params?)`
+
+Domain trust and verification scoring.
+
+```ts
+const trust = await client.trust("example.com");
+// trust.DBRecord.Established, trust.DBRecord.Ecommerce, etc.
+
+// With keyword checking
+const trustWords = await client.trust("example.com", {
+  words: "shop,buy,discount",
+  live: true,
+});
+```
+
+### `companyToUrl(companyName, params?)`
+
+Find domains associated with a company name.
+
+```ts
+const domains = await client.companyToUrl("Google");
+
+// Filter by TLD
+const comOnly = await client.companyToUrl("Google", {
+  tld: "com",
+  amount: 10,
+});
+```
+
+### `tags(lookup)`
+
+Get tracking and analytics tags found on a domain.
+
+```ts
+const tags = await client.tags("example.com");
+```
+
+### `recommendations(lookup)`
+
+Get technology recommendations for a domain.
+
+```ts
+const recs = await client.recommendations("example.com");
+```
+
+### `redirects(lookup)`
+
+Get inbound and outbound redirect chains.
+
+```ts
+const redirects = await client.redirects("example.com");
+// redirects.Inbound[], redirects.Outbound[]
+```
+
+### `product(query)`
+
+Search for products across e-commerce sites.
+
+```ts
+const products = await client.product("wireless headphones");
+// products.shops[].Products[]
+```
+
+## Response Format
+
+By default, responses are JSON (parsed and validated). You can request other formats:
+
+```ts
+const client = createClient(API_KEY, { responseFormat: "xml" });
+const xml = await client.free("example.com"); // returns raw XML string
+```
+
+Supported formats: `json`, `xml`, `txt`, `csv`, `tsv`
+
+::: warning
+Non-JSON formats return raw strings without type validation.
+:::
+
+## Error Handling
+
+```ts
+try {
+  const result = await client.free("example.com");
+} catch (err) {
+  if (err instanceof Error) {
+    // API errors: "BuiltWith API error 401: ..."
+    // Validation errors: ZodError with detailed field info
+    console.error(err.message);
+  }
+}
+```

--- a/docs/guide/library.md
+++ b/docs/guide/library.md
@@ -1,14 +1,24 @@
-# Library Usage
+# Library
+
+A typed TypeScript wrapper for the BuiltWith API with Zod-validated responses and full ESM support.
 
 ## Quick Start
+
+Create a client with your API key. All methods return typed, Zod-validated responses.
 
 ```ts
 import { createClient } from "builtwith-api";
 
 const client = createClient(process.env.BUILTWITH_API_KEY!);
-```
 
-All client methods return typed, Zod-validated responses. If the API returns unexpected data, a `ZodError` is thrown with details about which fields failed validation.
+// Free lookup — no API key required
+const profile = await client.free("google.com");
+
+// Full domain lookup with options
+const details = await client.domain("example.com", {
+  onlyLiveTechnologies: true,
+});
+```
 
 ## Methods
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,27 +2,27 @@
 layout: home
 hero:
   name: builtwith-api
-  text: Technology intelligence for your stack
-  tagline: Typed Node.js client, CLI, and MCP server for the BuiltWith API. Detect technologies, track trends, and discover relationships across the web.
+  text: A typed TypeScript wrapper for the BuiltWith API.
+  tagline: Query technology data from your code, your terminal, or your AI assistant.
   actions:
     - theme: brand
       text: Get Started
       link: /guide/
     - theme: alt
+      text: API Reference
+      link: /api/
+    - theme: alt
       text: View on GitHub
       link: https://github.com/zcaceres/builtwith-api
 
 features:
-  - title: TypeScript Library
-    details: Fully typed client with Zod-validated responses. Every endpoint returns structured data you can trust.
+  - title: TypeScript SDK
+    details: Import createClient and call any of 13 endpoints. Typed responses validated with Zod — no guessing at API shapes.
     link: /guide/library
-  - title: CLI
-    details: Query the BuiltWith API from your terminal. Pipe JSON output to jq, scripts, or dashboards.
+  - title: Command Line
+    details: Query the BuiltWith API from your terminal. Supports all 13 methods with flags for every parameter.
     link: /cli
-  - title: MCP Server
-    details: Connect BuiltWith to Claude, Cursor, and other AI tools via the Model Context Protocol.
+  - title: AI Assistant
+    details: Give Claude, Cursor, or any MCP-compatible tool direct access to BuiltWith lookups. Just add the config and ask.
     link: /mcp
-  - title: 13 API Endpoints
-    details: Domain profiling, technology trends, company lookups, trust scores, redirects, keywords, and more.
-    link: /guide/library#methods
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,28 +1,6 @@
 ---
-layout: home
-hero:
-  name: builtwith-api
-  text: A typed TypeScript wrapper for the BuiltWith API.
-  tagline: Query technology data from your code, your terminal, or your AI assistant.
-  actions:
-    - theme: brand
-      text: Get Started
-      link: /guide/
-    - theme: alt
-      text: API Reference
-      link: /api/
-    - theme: alt
-      text: View on GitHub
-      link: https://github.com/zcaceres/builtwith-api
-
-features:
-  - title: TypeScript SDK
-    details: Import createClient and call any of 13 endpoints. Typed responses validated with Zod — no guessing at API shapes.
-    link: /guide/library
-  - title: Command Line
-    details: Query the BuiltWith API from your terminal. Supports all 13 methods with flags for every parameter.
-    link: /cli
-  - title: AI Assistant
-    details: Give Claude, Cursor, or any MCP-compatible tool direct access to BuiltWith lookups. Just add the config and ask.
-    link: /mcp
+layout: page
+sidebar: false
 ---
+
+<HomePage />

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,28 @@
+---
+layout: home
+hero:
+  name: builtwith-api
+  text: Technology intelligence for your stack
+  tagline: Typed Node.js client, CLI, and MCP server for the BuiltWith API. Detect technologies, track trends, and discover relationships across the web.
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /guide/
+    - theme: alt
+      text: View on GitHub
+      link: https://github.com/zcaceres/builtwith-api
+
+features:
+  - title: TypeScript Library
+    details: Fully typed client with Zod-validated responses. Every endpoint returns structured data you can trust.
+    link: /guide/library
+  - title: CLI
+    details: Query the BuiltWith API from your terminal. Pipe JSON output to jq, scripts, or dashboards.
+    link: /cli
+  - title: MCP Server
+    details: Connect BuiltWith to Claude, Cursor, and other AI tools via the Model Context Protocol.
+    link: /mcp
+  - title: 13 API Endpoints
+    details: Domain profiling, technology trends, company lookups, trust scores, redirects, keywords, and more.
+    link: /guide/library#methods
+---

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -13,7 +13,7 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
   "mcpServers": {
     "builtwith": {
       "command": "npx",
-      "args": ["-y", "builtwith-api"],
+      "args": ["-y", "--package", "builtwith-api", "builtwith-mcp"],
       "env": {
         "BUILTWITH_API_KEY": "your-key-here"
       }
@@ -31,7 +31,7 @@ Add to your Claude Code settings:
   "mcpServers": {
     "builtwith": {
       "command": "npx",
-      "args": ["-y", "builtwith-api"],
+      "args": ["-y", "--package", "builtwith-api", "builtwith-mcp"],
       "env": {
         "BUILTWITH_API_KEY": "your-key-here"
       }
@@ -49,7 +49,7 @@ You can also pass the API key as a flag instead of an env var:
   "mcpServers": {
     "builtwith": {
       "command": "npx",
-      "args": ["-y", "builtwith-api", "--api-key", "your-key-here"]
+      "args": ["-y", "--package", "builtwith-api", "builtwith-mcp", "--api-key", "your-key-here"]
     }
   }
 }

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -2,11 +2,39 @@
 
 Expose BuiltWith API lookups as MCP tools for Claude Desktop, Cursor, and any MCP-compatible AI client.
 
+## How It Works
+
+The MCP server exposes all 13 BuiltWith API methods as tools. Your AI assistant can call them directly during conversation.
+
+**1. Configure** — Add the server config to your AI client's settings file.
+
+**2. Ask** — "What technologies does stripe.com use?" — your assistant calls the right tool.
+
+**3. Get Results** — Structured data returned inline. No copy-pasting from browser tabs.
+
 ## Setup
 
 ### Claude Desktop
 
 Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "builtwith": {
+      "command": "npx",
+      "args": ["-y", "--package", "builtwith-api", "builtwith-mcp"],
+      "env": {
+        "BUILTWITH_API_KEY": "your-key-here"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+Add to your Cursor MCP config (`.cursor/mcp.json` in your project or `~/.cursor/mcp.json` globally):
 
 ```json
 {
@@ -40,9 +68,15 @@ Add to your Claude Code settings:
 }
 ```
 
-### With `--api-key` flag
+### Other Clients
 
-You can also pass the API key as a flag instead of an env var:
+Any MCP-compatible client can use the server. The general pattern:
+
+- **Command:** `npx`
+- **Args:** `["-y", "--package", "builtwith-api", "builtwith-mcp"]`
+- **Env:** `BUILTWITH_API_KEY=your-key-here`
+
+Or pass the key as a flag:
 
 ```json
 {
@@ -55,48 +89,33 @@ You can also pass the API key as a flag instead of an env var:
 }
 ```
 
-### Local installation
-
-If you prefer a local install over `npx`:
+For a local install instead of `npx`:
 
 ```bash
 npm install -g builtwith-api
 ```
 
-Then use `builtwith-mcp` as the command:
-
-```json
-{
-  "mcpServers": {
-    "builtwith": {
-      "command": "builtwith-mcp",
-      "env": {
-        "BUILTWITH_API_KEY": "your-key-here"
-      }
-    }
-  }
-}
-```
+Then use `builtwith-mcp` as the command directly.
 
 ## Available Tools
 
-All tools are prefixed with `builtwith_`:
+All tools are prefixed with `builtwith_` and accept typed input schemas validated by Zod.
 
-| Tool | Description |
-|------|-------------|
-| `builtwith_free` | Basic technology profile for a domain |
-| `builtwith_domain` | Detailed technology profile with filters |
-| `builtwith_domainLive` | Real-time technology scan |
-| `builtwith_lists` | Domains using a specific technology |
-| `builtwith_trends` | Technology adoption trends |
-| `builtwith_relationships` | Related domains via shared identifiers |
-| `builtwith_keywords` | SEO keywords for a domain |
-| `builtwith_trust` | Domain trust and verification score |
-| `builtwith_companyToUrl` | Domains associated with a company |
-| `builtwith_tags` | Tracking/analytics tags on a domain |
-| `builtwith_recommendations` | Technology recommendations |
-| `builtwith_redirects` | Redirect chains |
-| `builtwith_product` | E-commerce product search |
+| Tool | Input | Description |
+|------|-------|-------------|
+| `builtwith_free` | `{ lookup: string }` | Basic technology profile |
+| `builtwith_domain` | `{ lookup, ...opts }` | Detailed tech profile with spend |
+| `builtwith_domainLive` | `{ lookup: string }` | Real-time technology scan |
+| `builtwith_lists` | `{ technology, ...opts }` | Domains using a technology |
+| `builtwith_trends` | `{ technology, ...opts }` | Technology adoption trends |
+| `builtwith_relationships` | `{ lookup }` | Related domains via shared identifiers |
+| `builtwith_keywords` | `{ lookup }` | Domain keywords |
+| `builtwith_trust` | `{ lookup, ...opts }` | Trust and verification score |
+| `builtwith_companyToUrl` | `{ companyName, ...opts }` | Domains for a company name |
+| `builtwith_tags` | `{ lookup }` | Tracking/analytics tags |
+| `builtwith_recommendations` | `{ lookup }` | Technology recommendations |
+| `builtwith_redirects` | `{ lookup }` | Redirect chains |
+| `builtwith_product` | `{ query }` | E-commerce product search |
 
 ## Testing
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,6 +1,6 @@
 # MCP Server
 
-The `builtwith-mcp` server exposes all 13 BuiltWith API endpoints as tools via the [Model Context Protocol](https://modelcontextprotocol.io/), making them available to Claude, Cursor, and other MCP-compatible AI tools.
+Expose BuiltWith API lookups as MCP tools for Claude Desktop, Cursor, and any MCP-compatible AI client.
 
 ## Setup
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,117 @@
+# MCP Server
+
+The `builtwith-mcp` server exposes all 13 BuiltWith API endpoints as tools via the [Model Context Protocol](https://modelcontextprotocol.io/), making them available to Claude, Cursor, and other MCP-compatible AI tools.
+
+## Setup
+
+### Claude Desktop
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "builtwith": {
+      "command": "npx",
+      "args": ["-y", "builtwith-api"],
+      "env": {
+        "BUILTWITH_API_KEY": "your-key-here"
+      }
+    }
+  }
+}
+```
+
+### Claude Code
+
+Add to your Claude Code settings:
+
+```json
+{
+  "mcpServers": {
+    "builtwith": {
+      "command": "npx",
+      "args": ["-y", "builtwith-api"],
+      "env": {
+        "BUILTWITH_API_KEY": "your-key-here"
+      }
+    }
+  }
+}
+```
+
+### With `--api-key` flag
+
+You can also pass the API key as a flag instead of an env var:
+
+```json
+{
+  "mcpServers": {
+    "builtwith": {
+      "command": "npx",
+      "args": ["-y", "builtwith-api", "--api-key", "your-key-here"]
+    }
+  }
+}
+```
+
+### Local installation
+
+If you prefer a local install over `npx`:
+
+```bash
+npm install -g builtwith-api
+```
+
+Then use `builtwith-mcp` as the command:
+
+```json
+{
+  "mcpServers": {
+    "builtwith": {
+      "command": "builtwith-mcp",
+      "env": {
+        "BUILTWITH_API_KEY": "your-key-here"
+      }
+    }
+  }
+}
+```
+
+## Available Tools
+
+All tools are prefixed with `builtwith_`:
+
+| Tool | Description |
+|------|-------------|
+| `builtwith_free` | Basic technology profile for a domain |
+| `builtwith_domain` | Detailed technology profile with filters |
+| `builtwith_domainLive` | Real-time technology scan |
+| `builtwith_lists` | Domains using a specific technology |
+| `builtwith_trends` | Technology adoption trends |
+| `builtwith_relationships` | Related domains via shared identifiers |
+| `builtwith_keywords` | SEO keywords for a domain |
+| `builtwith_trust` | Domain trust and verification score |
+| `builtwith_companyToUrl` | Domains associated with a company |
+| `builtwith_tags` | Tracking/analytics tags on a domain |
+| `builtwith_recommendations` | Technology recommendations |
+| `builtwith_redirects` | Redirect chains |
+| `builtwith_product` | E-commerce product search |
+
+## Testing
+
+Use the MCP Inspector to test the server:
+
+```bash
+npx @modelcontextprotocol/inspector node dist/mcp.js --api-key YOUR_KEY
+```
+
+## Example prompts
+
+Once configured, you can ask your AI assistant things like:
+
+- "What technologies does stripe.com use?"
+- "Find all domains using Shopify"
+- "What are the technology trends for React?"
+- "Is example.com a trustworthy domain?"
+- "What companies are related to example.com?"

--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,0 +1,1 @@
+builtwith.zach.dev

--- a/package.json
+++ b/package.json
@@ -37,7 +37,11 @@
     "lint:fix": "biome check --write src/ test/",
     "test": "bun test",
     "smoke": "bun test.ts",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "docs:api": "typedoc",
+    "docs:dev": "bun run docs:api && vitepress dev docs",
+    "docs:build": "bun run docs:api && vitepress build docs",
+    "docs:preview": "vitepress preview docs"
   },
   "homepage": "https://github.com/zcaceres/builtwith-api",
   "repository": {
@@ -64,7 +68,10 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.7",
     "@types/bun": "^1.3.9",
-    "typescript": "^5"
+    "typedoc": "^0.28.17",
+    "typedoc-plugin-markdown": "^4.10.0",
+    "typescript": "^5",
+    "vitepress": "^1.6.4"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,31 @@ const DOMAIN_BOOLEANS: BooleanMapping = {
   noPII: "NOPII",
 };
 
+/**
+ * Create a BuiltWith API client.
+ *
+ * @param apiKey - Your BuiltWith API key.
+ * @param moduleParams - Optional client configuration (e.g. response format).
+ * @returns A {@link BuiltWithClient} with methods for each BuiltWith API endpoint.
+ *
+ * @example
+ * ```ts
+ * import { createClient } from "builtwith-api";
+ *
+ * const client = createClient(process.env.BUILTWITH_API_KEY!);
+ *
+ * // Free lookup
+ * const profile = await client.free("example.com");
+ *
+ * // Domain lookup with filters
+ * const details = await client.domain("example.com", {
+ *   onlyLiveTechnologies: true,
+ * });
+ *
+ * // Multi-domain lookup
+ * const multi = await client.domain(["example.com", "other.com"]);
+ * ```
+ */
 export function createClient(apiKey: string, moduleParams: ClientOptions = {}): BuiltWithClient {
   if (!apiKey) {
     throw new Error("You must initialize the BuiltWith module with an api key");

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -363,6 +363,8 @@ export const TrustResponseSchema = z.strictObject({
     Established: z.boolean(),
     DBIndexed: z.boolean(),
   }),
+  // Intentionally loose — BuiltWith does not document the LiveRecord shape.
+  // Populated only when `live: true` is passed; otherwise null.
   LiveRecord: z.object({}).passthrough().nullable(),
   Status: z.number(),
 });

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -2,14 +2,31 @@ import { z } from "zod/v4";
 
 // ─── Input Schemas ───────────────────────────────────────────────────────────
 
+/** Supported API response formats. */
 export const ResponseFormatSchema = z.enum(["xml", "json", "txt", "csv", "tsv"]);
+/**
+ * Response format returned by the BuiltWith API.
+ *
+ * - `"json"` — parsed and validated (default)
+ * - `"xml"` / `"txt"` / `"csv"` / `"tsv"` — returned as raw strings
+ */
 export type ResponseFormat = z.infer<typeof ResponseFormatSchema>;
 
+/** Validation schema for {@link ClientOptions}. */
 export const ClientOptionsSchema = z.strictObject({
   responseFormat: ResponseFormatSchema.optional(),
 });
+/**
+ * Options passed to `createClient`.
+ *
+ * @example
+ * ```ts
+ * const client = createClient(API_KEY, { responseFormat: "xml" });
+ * ```
+ */
 export type ClientOptions = z.infer<typeof ClientOptionsSchema>;
 
+/** Validation schema for {@link DomainParams}. */
 export const DomainParamsSchema = z.strictObject({
   hideAll: z.boolean().optional(),
   hideDescriptionAndLinks: z.boolean().optional(),
@@ -20,30 +37,77 @@ export const DomainParamsSchema = z.strictObject({
   firstDetectedRange: z.string().optional(),
   lastDetectedRange: z.string().optional(),
 });
+/**
+ * Optional parameters for the Domain API endpoint.
+ *
+ * @example
+ * ```ts
+ * await client.domain("example.com", {
+ *   onlyLiveTechnologies: true,
+ *   hideAll: true,
+ * });
+ * ```
+ */
 export type DomainParams = z.infer<typeof DomainParamsSchema>;
 
+/** Validation schema for {@link ListsParams}. */
 export const ListsParamsSchema = z.strictObject({
   includeMetaData: z.boolean().optional(),
   offset: z.string().optional(),
   since: z.string().optional(),
 });
+/**
+ * Optional parameters for the Lists API endpoint.
+ *
+ * @example
+ * ```ts
+ * await client.lists("Shopify", { since: "2024-01-01" });
+ * ```
+ */
 export type ListsParams = z.infer<typeof ListsParamsSchema>;
 
+/** Validation schema for {@link TrendsParams}. */
 export const TrendsParamsSchema = z.strictObject({
   date: z.string().optional(),
 });
+/**
+ * Optional parameters for the Trends API endpoint.
+ *
+ * @example
+ * ```ts
+ * await client.trends("jQuery", { date: "2024-06" });
+ * ```
+ */
 export type TrendsParams = z.infer<typeof TrendsParamsSchema>;
 
+/** Validation schema for {@link CompanyToUrlParams}. */
 export const CompanyToUrlParamsSchema = z.strictObject({
   tld: z.string().optional(),
   amount: z.number().optional(),
 });
+/**
+ * Optional parameters for the Company-to-URL API endpoint.
+ *
+ * @example
+ * ```ts
+ * await client.companyToUrl("Google", { tld: "com", amount: 5 });
+ * ```
+ */
 export type CompanyToUrlParams = z.infer<typeof CompanyToUrlParamsSchema>;
 
+/** Validation schema for {@link TrustParams}. */
 export const TrustParamsSchema = z.strictObject({
   words: z.string().optional(),
   live: z.boolean().optional(),
 });
+/**
+ * Optional parameters for the Trust API endpoint.
+ *
+ * @example
+ * ```ts
+ * await client.trust("example.com", { words: "shop,buy", live: true });
+ * ```
+ */
 export type TrustParams = z.infer<typeof TrustParamsSchema>;
 
 export const SingleLookupSchema = z.string().min(1);
@@ -52,6 +116,7 @@ export const MultiLookupSchema = z.union([z.string().min(1), z.array(z.string().
 // ─── Response Schemas ────────────────────────────────────────────────────────
 // Use z.object() (loose/passthrough) to tolerate extra fields from the API
 
+/** Validation schema for {@link FreeResponse}. */
 export const FreeResponseSchema = z.object({
   domain: z.string(),
   first: z.number(),
@@ -75,6 +140,7 @@ export const FreeResponseSchema = z.object({
     }),
   ),
 });
+/** Response from the Free API — basic technology profile for a single domain. */
 export type FreeResponse = z.infer<typeof FreeResponseSchema>;
 
 const TechnologySchema = z.object({
@@ -136,6 +202,7 @@ const AttributesSchema = z.object({
   CMetrics: z.number(),
 });
 
+/** Validation schema for {@link DomainResponse}. */
 export const DomainResponseSchema = z.object({
   Results: z.array(
     z.object({
@@ -160,8 +227,10 @@ export const DomainResponseSchema = z.object({
   ),
   Errors: z.array(z.string()),
 });
+/** Response from the Domain API — detailed technology profile with metadata and attributes. */
 export type DomainResponse = z.infer<typeof DomainResponseSchema>;
 
+/** Validation schema for {@link ListsResponse}. */
 export const ListsResponseSchema = z.object({
   NextOffset: z.string(),
   Results: z.array(
@@ -185,8 +254,10 @@ export const ListsResponseSchema = z.object({
     }),
   ),
 });
+/** Response from the Lists API — domains using a specific technology. */
 export type ListsResponse = z.infer<typeof ListsResponseSchema>;
 
+/** Validation schema for {@link RelationshipsResponse}. */
 export const RelationshipsResponseSchema = z.object({
   Relationships: z.array(
     z.object({
@@ -215,8 +286,10 @@ export const RelationshipsResponseSchema = z.object({
   next_skip: z.number(),
   more_results: z.boolean(),
 });
+/** Response from the Relationships API — domains sharing identifiers (analytics IDs, ad accounts, etc.). */
 export type RelationshipsResponse = z.infer<typeof RelationshipsResponseSchema>;
 
+/** Validation schema for {@link KeywordsResponse}. */
 export const KeywordsResponseSchema = z.object({
   Keywords: z.array(
     z.object({
@@ -225,8 +298,10 @@ export const KeywordsResponseSchema = z.object({
     }),
   ),
 });
+/** Response from the Keywords API — SEO keywords associated with domains. */
 export type KeywordsResponse = z.infer<typeof KeywordsResponseSchema>;
 
+/** Validation schema for {@link TrendsResponse}. */
 export const TrendsResponseSchema = z.object({
   Tech: z.object({
     icon: z.string(),
@@ -246,8 +321,10 @@ export const TrendsResponseSchema = z.object({
     }),
   }),
 });
+/** Response from the Trends API — technology adoption coverage data. */
 export type TrendsResponse = z.infer<typeof TrendsResponseSchema>;
 
+/** Validation schema for {@link CompanyToUrlResponse}. */
 export const CompanyToUrlResponseSchema = z.array(
   z.object({
     Domain: z.string(),
@@ -263,8 +340,10 @@ export const CompanyToUrlResponseSchema = z.array(
     Socials: z.array(z.string()),
   }),
 );
+/** Response from the Company-to-URL API — domains associated with a company name. */
 export type CompanyToUrlResponse = z.infer<typeof CompanyToUrlResponseSchema>;
 
+/** Validation schema for {@link TrustResponse}. */
 export const TrustResponseSchema = z.object({
   Domain: z.string(),
   DBRecord: z.object({
@@ -283,8 +362,10 @@ export const TrustResponseSchema = z.object({
   LiveRecord: z.object({}).passthrough().nullable(),
   Status: z.number(),
 });
+/** Response from the Trust API — domain verification and trust score. */
 export type TrustResponse = z.infer<typeof TrustResponseSchema>;
 
+/** Validation schema for {@link TagsResponse}. */
 export const TagsResponseSchema = z.array(
   z.object({
     Value: z.string(),
@@ -297,8 +378,10 @@ export const TagsResponseSchema = z.array(
     ),
   }),
 );
+/** Response from the Tags API — tracking and analytics tags found on a domain. */
 export type TagsResponse = z.infer<typeof TagsResponseSchema>;
 
+/** Validation schema for {@link RecommendationsResponse}. */
 export const RecommendationsResponseSchema = z.array(
   z.object({
     Domain: z.string(),
@@ -315,8 +398,10 @@ export const RecommendationsResponseSchema = z.array(
     ),
   }),
 );
+/** Response from the Recommendations API — suggested technologies for a domain. */
 export type RecommendationsResponse = z.infer<typeof RecommendationsResponseSchema>;
 
+/** Validation schema for {@link RedirectsResponse}. */
 export const RedirectsResponseSchema = z.object({
   Lookup: z.string(),
   Inbound: z.array(
@@ -334,8 +419,10 @@ export const RedirectsResponseSchema = z.object({
     }),
   ),
 });
+/** Response from the Redirects API — inbound and outbound redirect chains. */
 export type RedirectsResponse = z.infer<typeof RedirectsResponseSchema>;
 
+/** Validation schema for {@link ProductResponse}. */
 export const ProductResponseSchema = z.object({
   query: z.string(),
   is_more: z.boolean(),
@@ -365,27 +452,83 @@ export const ProductResponseSchema = z.object({
     }),
   ),
 });
+/** Response from the Product API — e-commerce product search results. */
 export type ProductResponse = z.infer<typeof ProductResponseSchema>;
 
 // ─── Client Interface ────────────────────────────────────────────────────────
 
+/**
+ * The BuiltWith API client. Created via `createClient()`.
+ *
+ * All methods return validated, typed responses when using JSON format,
+ * or raw strings for XML/TXT/CSV/TSV formats.
+ *
+ * @example
+ * ```ts
+ * import { createClient } from "builtwith-api";
+ *
+ * const client = createClient(process.env.BUILTWITH_API_KEY!);
+ * const profile = await client.free("example.com");
+ * ```
+ */
 export interface BuiltWithClient {
+  /** Free lookup — basic technology profile for a single domain. */
   free(lookup: string): Promise<FreeResponse | string>;
+  /**
+   * Detailed technology profile for one or more domains.
+   * @param lookup - Single domain or array of up to 16 domains.
+   * @param params - Optional filters (hide fields, date ranges, etc.).
+   */
   domain(lookup: string | string[], params?: DomainParams): Promise<DomainResponse | string>;
+  /**
+   * List domains using a specific technology.
+   * @param technology - Technology name (e.g. "Shopify", "React").
+   * @param params - Optional pagination and filtering.
+   */
   lists(technology: string, params?: ListsParams): Promise<ListsResponse | string>;
+  /**
+   * Find related domains via shared identifiers (analytics IDs, ad accounts, etc.).
+   * @param lookup - Single domain or array of up to 16 domains.
+   */
   relationships(lookup: string | string[]): Promise<RelationshipsResponse | string>;
+  /**
+   * Get SEO keywords associated with one or more domains.
+   * @param lookup - Single domain or array of up to 16 domains.
+   */
   keywords(lookup: string | string[]): Promise<KeywordsResponse | string>;
+  /**
+   * Technology adoption trends and coverage data.
+   * @param technology - Technology name to look up.
+   * @param params - Optional date filter.
+   */
   trends(technology: string, params?: TrendsParams): Promise<TrendsResponse | string>;
+  /**
+   * Find domains associated with a company name.
+   * @param companyName - Company name to search.
+   * @param params - Optional TLD filter and result count.
+   */
   companyToUrl(companyName: string, params?: CompanyToUrlParams): Promise<CompanyToUrlResponse | string>;
+  /** Live technology lookup — scans the domain in real time. */
   domainLive(lookup: string): Promise<DomainResponse | string>;
+  /**
+   * Trust and verification score for a domain.
+   * @param lookup - Domain to look up.
+   * @param params - Optional keywords and live analysis toggle.
+   */
   trust(lookup: string, params?: TrustParams): Promise<TrustResponse | string>;
+  /** Get tracking and analytics tags found on a domain. */
   tags(lookup: string): Promise<TagsResponse | string>;
+  /** Get technology recommendations for a domain. */
   recommendations(lookup: string): Promise<RecommendationsResponse | string>;
+  /** Get inbound and outbound redirect chains for a domain. */
   redirects(lookup: string): Promise<RedirectsResponse | string>;
+  /** Search for products across e-commerce sites. */
   product(query: string): Promise<ProductResponse | string>;
 }
 
 // ─── Utility Types ───────────────────────────────────────────────────────────
 
+/** @internal Maps JS param names to BuiltWith API query string keys. */
 export type BooleanMapping = Record<string, string>;
+/** @internal URL query parameters — `undefined` values are omitted. */
 export type QueryParams = Record<string, string | number | undefined>;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -26,6 +26,9 @@ export const ClientOptionsSchema = z.strictObject({
  */
 export type ClientOptions = z.infer<typeof ClientOptionsSchema>;
 
+/** Matches YYYY-MM-DD or YYYY-MM-DD-YYYY-MM-DD date range format. */
+const dateRangePattern = /^\d{4}-\d{2}-\d{2}(-\d{4}-\d{2}-\d{2})?$/;
+
 /** Validation schema for {@link DomainParams}. */
 export const DomainParamsSchema = z.strictObject({
   hideAll: z.boolean().optional(),
@@ -34,8 +37,8 @@ export const DomainParamsSchema = z.strictObject({
   noMetaData: z.boolean().optional(),
   noAttributeData: z.boolean().optional(),
   noPII: z.boolean().optional(),
-  firstDetectedRange: z.string().optional(),
-  lastDetectedRange: z.string().optional(),
+  firstDetectedRange: z.string().regex(dateRangePattern, "Expected YYYY-MM-DD or YYYY-MM-DD-YYYY-MM-DD").optional(),
+  lastDetectedRange: z.string().regex(dateRangePattern, "Expected YYYY-MM-DD or YYYY-MM-DD-YYYY-MM-DD").optional(),
 });
 /**
  * Optional parameters for the Domain API endpoint.
@@ -114,22 +117,23 @@ export const SingleLookupSchema = z.string().min(1);
 export const MultiLookupSchema = z.union([z.string().min(1), z.array(z.string().min(1)).min(1).max(16)]);
 
 // ─── Response Schemas ────────────────────────────────────────────────────────
-// Use z.object() (loose/passthrough) to tolerate extra fields from the API
+// Use z.strictObject() to catch upstream API drift — if BuiltWith adds or
+// removes fields, the parse will fail, signaling the schema needs updating.
 
 /** Validation schema for {@link FreeResponse}. */
-export const FreeResponseSchema = z.object({
+export const FreeResponseSchema = z.strictObject({
   domain: z.string(),
   first: z.number(),
   last: z.number(),
   groups: z.array(
-    z.object({
+    z.strictObject({
       name: z.string(),
       live: z.number(),
       dead: z.number(),
       latest: z.number(),
       oldest: z.number(),
       categories: z.array(
-        z.object({
+        z.strictObject({
           live: z.number(),
           dead: z.number(),
           latest: z.number(),
@@ -143,7 +147,7 @@ export const FreeResponseSchema = z.object({
 /** Response from the Free API — basic technology profile for a single domain. */
 export type FreeResponse = z.infer<typeof FreeResponseSchema>;
 
-const TechnologySchema = z.object({
+const TechnologySchema = z.strictObject({
   Name: z.string(),
   Description: z.string(),
   Link: z.string(),
@@ -155,7 +159,7 @@ const TechnologySchema = z.object({
   Categories: z.array(z.string()).optional(),
 });
 
-const PathSchema = z.object({
+const PathSchema = z.strictObject({
   Technologies: z.array(TechnologySchema),
   FirstIndexed: z.number(),
   LastIndexed: z.number(),
@@ -164,7 +168,7 @@ const PathSchema = z.object({
   SubDomain: z.string(),
 });
 
-const MetaSchema = z.object({
+const MetaSchema = z.strictObject({
   Majestic: z.number(),
   Vertical: z.string(),
   Social: z.array(z.string()),
@@ -176,7 +180,7 @@ const MetaSchema = z.object({
   Postcode: z.string(),
   Country: z.string(),
   Names: z.array(
-    z.object({
+    z.strictObject({
       Name: z.string(),
       Type: z.number(),
       Level: z.string(),
@@ -187,7 +191,7 @@ const MetaSchema = z.object({
   QRank: z.number(),
 });
 
-const AttributesSchema = z.object({
+const AttributesSchema = z.strictObject({
   MJRank: z.number(),
   MJTLDRank: z.number(),
   RefSN: z.number(),
@@ -203,12 +207,12 @@ const AttributesSchema = z.object({
 });
 
 /** Validation schema for {@link DomainResponse}. */
-export const DomainResponseSchema = z.object({
+export const DomainResponseSchema = z.strictObject({
   Results: z.array(
-    z.object({
-      Result: z.object({
+    z.strictObject({
+      Result: z.strictObject({
         SpendHistory: z.array(
-          z.object({
+          z.strictObject({
             D: z.number(),
             S: z.number(),
           }),
@@ -231,10 +235,10 @@ export const DomainResponseSchema = z.object({
 export type DomainResponse = z.infer<typeof DomainResponseSchema>;
 
 /** Validation schema for {@link ListsResponse}. */
-export const ListsResponseSchema = z.object({
+export const ListsResponseSchema = z.strictObject({
   NextOffset: z.string(),
   Results: z.array(
-    z.object({
+    z.strictObject({
       D: z.string(),
       FI: z.number().optional(),
       LI: z.number().optional(),
@@ -258,18 +262,18 @@ export const ListsResponseSchema = z.object({
 export type ListsResponse = z.infer<typeof ListsResponseSchema>;
 
 /** Validation schema for {@link RelationshipsResponse}. */
-export const RelationshipsResponseSchema = z.object({
+export const RelationshipsResponseSchema = z.strictObject({
   Relationships: z.array(
-    z.object({
+    z.strictObject({
       Domain: z.string(),
       Identifiers: z.array(
-        z.object({
+        z.strictObject({
           Value: z.string(),
           Type: z.string(),
           First: z.number(),
           Last: z.number(),
           Matches: z.array(
-            z.object({
+            z.strictObject({
               Domain: z.string(),
               First: z.number(),
               Last: z.number(),
@@ -290,9 +294,9 @@ export const RelationshipsResponseSchema = z.object({
 export type RelationshipsResponse = z.infer<typeof RelationshipsResponseSchema>;
 
 /** Validation schema for {@link KeywordsResponse}. */
-export const KeywordsResponseSchema = z.object({
+export const KeywordsResponseSchema = z.strictObject({
   Keywords: z.array(
-    z.object({
+    z.strictObject({
       Domain: z.string(),
       Keywords: z.array(z.string()),
     }),
@@ -302,8 +306,8 @@ export const KeywordsResponseSchema = z.object({
 export type KeywordsResponse = z.infer<typeof KeywordsResponseSchema>;
 
 /** Validation schema for {@link TrendsResponse}. */
-export const TrendsResponseSchema = z.object({
-  Tech: z.object({
+export const TrendsResponseSchema = z.strictObject({
+  Tech: z.strictObject({
     icon: z.string(),
     categories: z.array(z.string()),
     tag: z.string(),
@@ -312,7 +316,7 @@ export const TrendsResponseSchema = z.object({
     description: z.string(),
     link: z.string(),
     trends_link: z.string(),
-    coverage: z.object({
+    coverage: z.strictObject({
       ten_k: z.number(),
       hundred_k: z.number(),
       milly: z.number(),
@@ -326,7 +330,7 @@ export type TrendsResponse = z.infer<typeof TrendsResponseSchema>;
 
 /** Validation schema for {@link CompanyToUrlResponse}. */
 export const CompanyToUrlResponseSchema = z.array(
-  z.object({
+  z.strictObject({
     Domain: z.string(),
     CompanyName: z.string(),
     Spend: z.number(),
@@ -344,9 +348,9 @@ export const CompanyToUrlResponseSchema = z.array(
 export type CompanyToUrlResponse = z.infer<typeof CompanyToUrlResponseSchema>;
 
 /** Validation schema for {@link TrustResponse}. */
-export const TrustResponseSchema = z.object({
+export const TrustResponseSchema = z.strictObject({
   Domain: z.string(),
-  DBRecord: z.object({
+  DBRecord: z.strictObject({
     EarliestRecord: z.number(),
     LatestUpdate: z.number(),
     PremiumTechs: z.number(),
@@ -367,10 +371,10 @@ export type TrustResponse = z.infer<typeof TrustResponseSchema>;
 
 /** Validation schema for {@link TagsResponse}. */
 export const TagsResponseSchema = z.array(
-  z.object({
+  z.strictObject({
     Value: z.string(),
     Matches: z.array(
-      z.object({
+      z.strictObject({
         Domain: z.string(),
         First: z.string(),
         Last: z.string(),
@@ -383,11 +387,11 @@ export type TagsResponse = z.infer<typeof TagsResponseSchema>;
 
 /** Validation schema for {@link RecommendationsResponse}. */
 export const RecommendationsResponseSchema = z.array(
-  z.object({
+  z.strictObject({
     Domain: z.string(),
     Compiled: z.string(),
     Recommendations: z.array(
-      z.object({
+      z.strictObject({
         link: z.string(),
         name: z.string(),
         tag: z.string(),
@@ -402,17 +406,17 @@ export const RecommendationsResponseSchema = z.array(
 export type RecommendationsResponse = z.infer<typeof RecommendationsResponseSchema>;
 
 /** Validation schema for {@link RedirectsResponse}. */
-export const RedirectsResponseSchema = z.object({
+export const RedirectsResponseSchema = z.strictObject({
   Lookup: z.string(),
   Inbound: z.array(
-    z.object({
+    z.strictObject({
       Domain: z.string(),
       FirstDetected: z.string(),
       LastDetected: z.string(),
     }),
   ),
   Outbound: z.array(
-    z.object({
+    z.strictObject({
       Domain: z.string(),
       FirstDetected: z.string(),
       LastDetected: z.string(),
@@ -423,7 +427,7 @@ export const RedirectsResponseSchema = z.object({
 export type RedirectsResponse = z.infer<typeof RedirectsResponseSchema>;
 
 /** Validation schema for {@link ProductResponse}. */
-export const ProductResponseSchema = z.object({
+export const ProductResponseSchema = z.strictObject({
   query: z.string(),
   is_more: z.boolean(),
   page: z.number(),
@@ -436,10 +440,10 @@ export const ProductResponseSchema = z.object({
   used_this_query: z.number(),
   next_page: z.string(),
   shops: z.array(
-    z.object({
+    z.strictObject({
       Domain: z.string(),
       Products: z.array(
-        z.object({
+        z.strictObject({
           Title: z.string(),
           Url: z.string(),
           Indexed: z.string(),

--- a/test/params.test.ts
+++ b/test/params.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { booleanParams, buildURL, cleanWords, toQueryString, validateLookup } from "../src/params";
+import { DomainParamsSchema } from "../src/schemas";
 
 describe("toQueryString", () => {
   it("filters out undefined values", () => {
@@ -105,5 +106,31 @@ describe("validateLookup", () => {
   it("throws when array length > 16", () => {
     const domains = Array.from({ length: 17 }, (_, i) => `d${i}.com`);
     expect(() => validateLookup(domains, { multi: true })).toThrow();
+  });
+});
+
+describe("date range validation", () => {
+  it("accepts YYYY-MM-DD format", () => {
+    expect(() => DomainParamsSchema.parse({ firstDetectedRange: "2024-01-15" })).not.toThrow();
+  });
+
+  it("accepts YYYY-MM-DD-YYYY-MM-DD range format", () => {
+    expect(() => DomainParamsSchema.parse({ firstDetectedRange: "2020-01-01-2024-12-31" })).not.toThrow();
+  });
+
+  it("accepts lastDetectedRange with valid format", () => {
+    expect(() => DomainParamsSchema.parse({ lastDetectedRange: "2023-06-15" })).not.toThrow();
+  });
+
+  it("rejects invalid date range format", () => {
+    expect(() => DomainParamsSchema.parse({ firstDetectedRange: "January 2024" })).toThrow();
+  });
+
+  it("rejects partial date", () => {
+    expect(() => DomainParamsSchema.parse({ firstDetectedRange: "2024-01" })).toThrow();
+  });
+
+  it("rejects random string", () => {
+    expect(() => DomainParamsSchema.parse({ lastDetectedRange: "not-a-date" })).toThrow();
   });
 });

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { z } from "zod/v4";
+import { request, requestSafe } from "../src/request";
+
+const TestSchema = z.strictObject({ id: z.number(), name: z.string() });
+
+// Save original fetch so we can restore it
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("request", () => {
+  it("parses valid JSON response", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response(JSON.stringify({ id: 1, name: "test" }), { status: 200 })),
+    );
+    const result = await request("https://api.example.com/test", "json", TestSchema);
+    expect(result).toEqual({ id: 1, name: "test" });
+  });
+
+  it("returns raw text for XML format", async () => {
+    globalThis.fetch = mock(() => Promise.resolve(new Response("<root><id>1</id></root>", { status: 200 })));
+    const result = await request("https://api.example.com/test", "xml", TestSchema);
+    expect(result).toBe("<root><id>1</id></root>");
+  });
+
+  it("returns raw text for CSV format", async () => {
+    globalThis.fetch = mock(() => Promise.resolve(new Response("id,name\n1,test", { status: 200 })));
+    const result = await request("https://api.example.com/test", "csv", TestSchema);
+    expect(result).toBe("id,name\n1,test");
+  });
+
+  it("throws on HTTP 400", async () => {
+    globalThis.fetch = mock(() => Promise.resolve(new Response("Bad Request", { status: 400 })));
+    await expect(request("https://api.example.com/test", "json", TestSchema)).rejects.toThrow(
+      "BuiltWith API error 400: Bad Request",
+    );
+  });
+
+  it("throws on HTTP 401", async () => {
+    globalThis.fetch = mock(() => Promise.resolve(new Response("Unauthorized", { status: 401 })));
+    await expect(request("https://api.example.com/test", "json", TestSchema)).rejects.toThrow(
+      "BuiltWith API error 401: Unauthorized",
+    );
+  });
+
+  it("throws on HTTP 500", async () => {
+    globalThis.fetch = mock(() => Promise.resolve(new Response("Internal Server Error", { status: 500 })));
+    await expect(request("https://api.example.com/test", "json", TestSchema)).rejects.toThrow(
+      "BuiltWith API error 500: Internal Server Error",
+    );
+  });
+
+  it("throws ZodError on schema mismatch", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response(JSON.stringify({ id: "not-a-number", name: "test" }), { status: 200 })),
+    );
+    await expect(request("https://api.example.com/test", "json", TestSchema)).rejects.toThrow();
+  });
+
+  it("throws on network failure", async () => {
+    globalThis.fetch = mock(() => Promise.reject(new TypeError("fetch failed")));
+    await expect(request("https://api.example.com/test", "json", TestSchema)).rejects.toThrow("fetch failed");
+  });
+});
+
+describe("requestSafe", () => {
+  it("parses valid JSON response", async () => {
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response(JSON.stringify({ id: 1, name: "test" }), { status: 200 })),
+    );
+    const result = await requestSafe("https://api.example.com/test", "json", TestSchema);
+    expect(result).toEqual({ id: 1, name: "test" });
+  });
+
+  it("falls back to raw text on malformed JSON", async () => {
+    globalThis.fetch = mock(() => Promise.resolve(new Response("this is not json {{{", { status: 200 })));
+    const result = await requestSafe("https://api.example.com/test", "json", TestSchema);
+    expect(result).toBe("this is not json {{{");
+  });
+
+  it("throws on HTTP errors", async () => {
+    globalThis.fetch = mock(() => Promise.resolve(new Response("Service Unavailable", { status: 503 })));
+    await expect(requestSafe("https://api.example.com/test", "json", TestSchema)).rejects.toThrow(
+      "BuiltWith API error 503: Service Unavailable",
+    );
+  });
+
+  it("returns raw text for TSV format", async () => {
+    globalThis.fetch = mock(() => Promise.resolve(new Response("id\tname\n1\ttest", { status: 200 })));
+    const result = await requestSafe("https://api.example.com/test", "tsv", TestSchema);
+    expect(result).toBe("id\tname\n1\ttest");
+  });
+
+  it("throws ZodError on valid JSON that doesn't match schema", async () => {
+    globalThis.fetch = mock(() => Promise.resolve(new Response(JSON.stringify({ wrong: "shape" }), { status: 200 })));
+    await expect(requestSafe("https://api.example.com/test", "json", TestSchema)).rejects.toThrow();
+  });
+
+  it("throws on network failure", async () => {
+    globalThis.fetch = mock(() => Promise.reject(new Error("DNS resolution failed")));
+    await expect(requestSafe("https://api.example.com/test", "json", TestSchema)).rejects.toThrow(
+      "DNS resolution failed",
+    );
+  });
+});

--- a/test/schemas.test.ts
+++ b/test/schemas.test.ts
@@ -48,9 +48,9 @@ describe("FreeResponseSchema", () => {
     expect(() => FreeResponseSchema.parse(bad)).toThrow();
   });
 
-  it("tolerates extra fields", () => {
+  it("rejects extra fields", () => {
     const extra = { ...valid, extraField: true };
-    expect(() => FreeResponseSchema.parse(extra)).not.toThrow();
+    expect(() => FreeResponseSchema.parse(extra)).toThrow();
   });
 });
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,12 @@
+{
+  "entryPoints": ["src/index.ts", "src/schemas.ts"],
+  "out": "docs/api",
+  "plugin": ["typedoc-plugin-markdown"],
+  "outputFileStrategy": "modules",
+  "excludeInternal": true,
+  "excludePrivate": true,
+  "readme": "none",
+  "hidePageHeader": true,
+  "hideBreadcrumbs": true,
+  "useCodeBlocks": true
+}


### PR DESCRIPTION
## Summary

- Add JSDoc docstrings to all public API surfaces (`createClient`, `BuiltWithClient` interface, all param/response types, validation schemas)
- Set up VitePress documentation site with custom theme matching our design system (Space Grotesk, Inter, JetBrains Mono, terracotta `#C45D3E` accent, warm palette)
- Create 5 docs pages: landing (hero + features), introduction, installation, library usage (full method reference), CLI guide, MCP server setup
- Configure TypeDoc + typedoc-plugin-markdown to auto-generate API reference from docstrings
- Add GitHub Pages deploy workflow (`.github/workflows/docs.yml`) triggered on push to main
- Add `docs:dev`, `docs:build`, `docs:preview`, `docs:api` scripts

## Test plan

- [ ] `bun run build` — source still compiles
- [ ] `bun run lint` — no new lint issues
- [ ] `bun test` — all 88 tests pass
- [ ] `bun run docs:build` — docs site builds without errors
- [ ] `bun run docs:dev` — local preview shows all pages correctly
- [ ] After merge, verify GitHub Pages deployment at `zcaceres.github.io/builtwith-api/`
- [ ] Enable GitHub Pages (Settings > Pages > Source: GitHub Actions) if not already enabled