### PR TITLE
feat: add 'Built by zach.dev' widget to docs

### DIFF
--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,0 +1,21 @@
+<script setup>
+import DefaultTheme from 'vitepress/theme'
+import { ref } from 'vue'
+
+const { Layout } = DefaultTheme
+const dismissed = ref(false)
+</script>
+
+<template>
+  <Layout>
+    <template #layout-bottom>
+      <div v-if="!dismissed" class="zach-footer-logo">
+        <button class="zach-footer-dismiss" @click.stop.prevent="dismissed = true" aria-label="Dismiss">&times;</button>
+        <a href="https://zach.dev" target="_blank" rel="noopener noreferrer">
+          <img src="https://zach.dev/images/statue.png" alt="zach.dev" class="zach-footer-statue" />
+          <span class="zach-footer-text">Built by zach.dev</span>
+        </a>
+      </div>
+    </template>
+  </Layout>
+</template>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -68,3 +68,96 @@
   background-color: var(--vp-c-brand-soft);
   color: var(--vp-c-brand-1);
 }
+
+/* ── zach.dev Footer Logo ── */
+.zach-footer-logo {
+  position: fixed;
+  bottom: 24px;
+  right: 28px;
+  z-index: 50;
+}
+
+.zach-footer-logo a {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-decoration: none;
+  gap: 8px;
+  opacity: 0.85;
+  transition: opacity 0.2s ease;
+}
+
+.zach-footer-logo a:hover {
+  opacity: 1;
+}
+
+.zach-footer-dismiss {
+  position: absolute;
+  top: -12px;
+  right: -12px;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 50%;
+  background: var(--vp-c-bg-alt);
+  border: 1px solid var(--vp-c-divider);
+  color: var(--vp-c-text-2);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 10;
+  padding: 0;
+}
+
+.zach-footer-logo:hover .zach-footer-dismiss {
+  opacity: 1;
+}
+
+.zach-footer-dismiss:hover {
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-bg-elv);
+}
+
+.zach-footer-statue {
+  width: 64px;
+  height: 64px;
+  object-fit: contain;
+}
+
+.zach-footer-text {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--vp-c-text-2);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+@media (max-width: 768px) {
+  .zach-footer-logo {
+    bottom: 12px;
+    right: 12px;
+  }
+
+  .zach-footer-statue {
+    width: 36px;
+    height: 36px;
+  }
+
+  .zach-footer-text {
+    font-size: 10px;
+  }
+
+  .zach-footer-dismiss {
+    opacity: 1;
+    top: -10px;
+    right: -10px;
+    width: 24px;
+    height: 24px;
+    font-size: 14px;
+  }
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,9 +1,11 @@
 import DefaultTheme from "vitepress/theme";
+import Layout from "./Layout.vue";
 import HomePage from "./HomePage.vue";
 import "./custom.css";
 
 export default {
   extends: DefaultTheme,
+  Layout,
   enhanceApp({ app }) {
     app.component("HomePage", HomePage);
   },


### PR DESCRIPTION
## Summary

- Adds a fixed bottom-right "Built by zach.dev" widget to the docs site, matching the spotify-cli implementation
- Includes statue image, link to zach.dev, dismissible via × button
- Responsive sizing for mobile

## Test plan

- [x] Verified locally with `bun run docs:dev` — widget renders correctly in dark mode
- [ ] Confirm widget appears on deployed docs at builtwith.zach.dev