### PR TITLE
Upgrade Domain API to v23 and sync response schemas with current API fields

### DIFF
--- a/packages/builtwith-api/src/index.ts
+++ b/packages/builtwith-api/src/index.ts
@@ -96,7 +96,7 @@ export function createClient(apiKey: string, moduleParams: ClientOptions = {}): 
       validateLookup(lookup, { multi: true });
       if (params) DomainParamsSchema.parse(params);
       return get(
-        url("v22", {
+        url("v23", {
           LOOKUP: Array.isArray(lookup) ? lookup.join(",") : lookup,
           ...booleanParams(params, DOMAIN_BOOLEANS),
           FDRANGE: params?.firstDetectedRange,

--- a/packages/builtwith-api/src/schemas.ts
+++ b/packages/builtwith-api/src/schemas.ts
@@ -148,6 +148,7 @@ export const FreeResponseSchema = z.strictObject({
 export type FreeResponse = z.infer<typeof FreeResponseSchema>;
 
 const TechnologySchema = z.strictObject({
+  Id: z.number(),
   Name: z.string(),
   Description: z.string(),
   Link: z.string(),
@@ -207,6 +208,15 @@ const AttributesSchema = z.strictObject({
   Followers: z.number(),
   Employees: z.number(),
   ProductCount: z.number().optional(),
+  Revenue: z.number().optional(),
+  PageRank: z.number().optional(),
+  BWRank: z.number().optional(),
+  Tranco: z.number().optional(),
+  BWS: z.number().optional(),
+  AIMaturity: z.number().optional(),
+  AIOpenness: z.number().optional(),
+  AIReadiness: z.number().optional(),
+  AIVisibility: z.number().optional(),
 });
 
 /** Validation schema for {@link DomainResponse}. */

--- a/packages/builtwith-api/test/params.test.ts
+++ b/packages/builtwith-api/test/params.test.ts
@@ -72,10 +72,10 @@ describe("buildURL", () => {
   });
 
   it("appends query string when params have values", () => {
-    const result = buildURL("KEY123", "json", "v22", {
+    const result = buildURL("KEY123", "json", "v23", {
       LOOKUP: "example.com",
     });
-    expect(result).toBe("https://api.builtwith.com/v22/api.json?KEY=KEY123&LOOKUP=example.com");
+    expect(result).toBe("https://api.builtwith.com/v23/api.json?KEY=KEY123&LOOKUP=example.com");
   });
 
   it("no trailing & when params are all undefined", () => {

--- a/packages/builtwith-api/test/schemas.test.ts
+++ b/packages/builtwith-api/test/schemas.test.ts
@@ -66,6 +66,7 @@ describe("DomainResponseSchema", () => {
             {
               Technologies: [
                 {
+                  Id: 1515848251,
                   Name: "jQuery",
                   Description: "JS library",
                   Link: "https://jquery.com",


### PR DESCRIPTION
Hi Zach! 👋 Gary from BuiltWith here.

We recently released Domain API **v23** on our side, and this PR brings the client up to date. It's deliberately small:

- **`src/index.ts`**: `domain()` now calls `v23/api.json` instead of `v22`. v23 is a superset of v22 — the only structural change is a new numeric `Id` on each technology entry (a stable technology identifier).
- **`src/schemas.ts`**: added `Id: z.number()` to `TechnologySchema`, and added the attribute fields the API now returns (`Revenue`, `PageRank`, `BWRank`, `Tranco`, `BWS`, `AIMaturity`, `AIOpenness`, `AIReadiness`, `AIVisibility`, all optional numbers). Your `strictObject` drift-detection did its job here — these attributes are returned by v22 as well today, so current strict parses fail on domains that have them; this fixes that too.
- **Tests**: updated the URL expectation and the domain fixture accordingly.

Verified locally: `bun test` passes (145 pass / 0 fail), and the strict schemas parse live v23 responses for builtwith.com, example.com, and shopify.com.

If it looks good, we'd love a release/publish to npm when you get a chance — no rush and thanks for maintaining this! Alternatively, if you'd rather hand off npm publishing, adding `garazy` as a package maintainer works for us too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)